### PR TITLE
Status History + Application Detail Page

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/domain/ApplicationStatusHistory.kt
+++ b/backend/src/main/kotlin/com/nextrole/domain/ApplicationStatusHistory.kt
@@ -1,0 +1,23 @@
+package com.nextrole.domain
+
+import jakarta.persistence.*
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "application_status_history")
+class ApplicationStatusHistory(
+	@Id
+	@Column(nullable = false, updatable = false)
+	val id: UUID = UUID.randomUUID(),
+
+	@Column(name = "application_id", nullable = false)
+	val applicationId: UUID,
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	val status: ApplicationStatus,
+
+	@Column(name = "changed_at", nullable = false, updatable = false)
+	val changedAt: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/com/nextrole/repository/ApplicationStatusHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/ApplicationStatusHistoryRepository.kt
@@ -1,0 +1,9 @@
+package com.nextrole.repository
+
+import com.nextrole.domain.ApplicationStatusHistory
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ApplicationStatusHistoryRepository : JpaRepository<ApplicationStatusHistory, UUID> {
+	fun findByApplicationIdOrderByChangedAtAsc(applicationId: UUID): List<ApplicationStatusHistory>
+}

--- a/backend/src/main/kotlin/com/nextrole/service/ApplicationService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/ApplicationService.kt
@@ -1,8 +1,11 @@
 package com.nextrole.service
 
 import com.nextrole.domain.Application
+import com.nextrole.domain.ApplicationStatus
+import com.nextrole.domain.ApplicationStatusHistory
 import com.nextrole.exception.ApplicationNotFoundException
 import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.ApplicationStatusHistoryRepository
 import com.nextrole.web.dto.CreateApplicationRequest
 import com.nextrole.web.dto.UpdateApplicationRequest
 import org.springframework.data.domain.Page
@@ -13,7 +16,8 @@ import java.util.UUID
 
 @Service
 class ApplicationService(
-	private val applicationRepository: ApplicationRepository
+	private val applicationRepository: ApplicationRepository,
+	private val statusHistoryRepository: ApplicationStatusHistoryRepository
 ) {
 
 	fun create(userId: UUID, request: CreateApplicationRequest): Application {
@@ -30,7 +34,9 @@ class ApplicationService(
 			status = request.status,
 			notes = request.notes
 		)
-		return applicationRepository.save(application)
+		val saved = applicationRepository.save(application)
+		recordStatusChange(saved.id, saved.status)
+		return saved
 	}
 
 	fun list(userId: UUID, pageable: Pageable): Page<Application> =
@@ -50,14 +56,35 @@ class ApplicationService(
 		request.techStack?.let { application.techStack = it }
 		request.jobDescription?.let { application.jobDescription = it }
 		request.applicationDate?.let { application.applicationDate = it }
-		request.status?.let { application.status = it }
 		request.notes?.let { application.notes = it }
+		if (request.status != null && request.status != application.status) {
+			application.status = request.status
+			recordStatusChange(application.id, application.status)
+		}
 		application.updatedAt = Instant.now()
 		return applicationRepository.save(application)
+	}
+
+	fun changeStatus(userId: UUID, id: UUID, status: ApplicationStatus): Application {
+		val application = get(userId, id)
+		application.status = status
+		application.updatedAt = Instant.now()
+		val saved = applicationRepository.save(application)
+		recordStatusChange(saved.id, saved.status)
+		return saved
+	}
+
+	fun getHistory(userId: UUID, id: UUID): List<ApplicationStatusHistory> {
+		get(userId, id)
+		return statusHistoryRepository.findByApplicationIdOrderByChangedAtAsc(id)
 	}
 
 	fun delete(userId: UUID, id: UUID) {
 		val application = get(userId, id)
 		applicationRepository.delete(application)
+	}
+
+	private fun recordStatusChange(applicationId: UUID, status: ApplicationStatus) {
+		statusHistoryRepository.save(ApplicationStatusHistory(applicationId = applicationId, status = status))
 	}
 }

--- a/backend/src/main/kotlin/com/nextrole/web/ApplicationController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/ApplicationController.kt
@@ -3,7 +3,9 @@ package com.nextrole.web
 import com.nextrole.security.CurrentUser
 import com.nextrole.service.ApplicationService
 import com.nextrole.web.dto.ApplicationResponse
+import com.nextrole.web.dto.ChangeStatusRequest
 import com.nextrole.web.dto.CreateApplicationRequest
+import com.nextrole.web.dto.StatusHistoryResponse
 import com.nextrole.web.dto.UpdateApplicationRequest
 import com.nextrole.web.dto.toResponse
 import jakarta.validation.Valid
@@ -43,4 +45,12 @@ class ApplicationController(
 		applicationService.delete(CurrentUser.id(), id)
 		return ResponseEntity.noContent().build()
 	}
+
+	@PostMapping("/{id}/status")
+	fun changeStatus(@PathVariable id: UUID, @Valid @RequestBody request: ChangeStatusRequest): ApplicationResponse =
+		applicationService.changeStatus(CurrentUser.id(), id, request.status).toResponse()
+
+	@GetMapping("/{id}/history")
+	fun history(@PathVariable id: UUID): List<StatusHistoryResponse> =
+		applicationService.getHistory(CurrentUser.id(), id).map { it.toResponse() }
 }

--- a/backend/src/main/kotlin/com/nextrole/web/dto/StatusHistoryDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/StatusHistoryDtos.kt
@@ -1,0 +1,23 @@
+package com.nextrole.web.dto
+
+import com.nextrole.domain.ApplicationStatus
+import com.nextrole.domain.ApplicationStatusHistory
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+import java.util.UUID
+
+data class ChangeStatusRequest(
+	@field:NotNull val status: ApplicationStatus
+)
+
+data class StatusHistoryResponse(
+	val id: UUID,
+	val status: ApplicationStatus,
+	val changedAt: Instant
+)
+
+fun ApplicationStatusHistory.toResponse() = StatusHistoryResponse(
+	id = id,
+	status = status,
+	changedAt = changedAt
+)

--- a/backend/src/main/resources/db/migration/V2__status_history.sql
+++ b/backend/src/main/resources/db/migration/V2__status_history.sql
@@ -1,0 +1,8 @@
+CREATE TABLE application_status_history (
+	id UUID PRIMARY KEY,
+	application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+	status VARCHAR(50) NOT NULL,
+	changed_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_status_history_application_id ON application_status_history(application_id);

--- a/backend/src/test/kotlin/com/nextrole/service/ApplicationServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/ApplicationServiceTest.kt
@@ -2,13 +2,16 @@ package com.nextrole.service
 
 import com.nextrole.domain.Application
 import com.nextrole.domain.ApplicationStatus
+import com.nextrole.domain.ApplicationStatusHistory
 import com.nextrole.exception.ApplicationNotFoundException
 import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.ApplicationStatusHistoryRepository
 import com.nextrole.web.dto.CreateApplicationRequest
 import com.nextrole.web.dto.UpdateApplicationRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -17,13 +20,16 @@ import java.util.UUID
 class ApplicationServiceTest {
 
 	private val applicationRepository = mockk<ApplicationRepository>()
-	private val applicationService = ApplicationService(applicationRepository)
+	private val statusHistoryRepository = mockk<ApplicationStatusHistoryRepository>()
+	private val applicationService = ApplicationService(applicationRepository, statusHistoryRepository)
 	private val userId = UUID.randomUUID()
 
 	@Test
-	fun `create saves an application scoped to the current user`() {
+	fun `create saves an application scoped to the current user and records initial status`() {
 		val savedSlot = slot<Application>()
 		every { applicationRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+		val historySlot = slot<ApplicationStatusHistory>()
+		every { statusHistoryRepository.save(capture(historySlot)) } answers { historySlot.captured }
 
 		val request = CreateApplicationRequest(company = "Acme", role = "Backend Engineer")
 		val result = applicationService.create(userId, request)
@@ -31,6 +37,8 @@ class ApplicationServiceTest {
 		assertEquals(userId, savedSlot.captured.userId)
 		assertEquals("Acme", result.company)
 		assertEquals(ApplicationStatus.SAVED, result.status)
+		assertEquals(ApplicationStatus.SAVED, historySlot.captured.status)
+		assertEquals(result.id, historySlot.captured.applicationId)
 	}
 
 	@Test
@@ -48,6 +56,7 @@ class ApplicationServiceTest {
 		val existing = Application(userId = userId, company = "Acme", role = "Backend Engineer", location = "Berlin")
 		every { applicationRepository.findByIdAndUserId(existing.id, userId) } returns existing
 		every { applicationRepository.save(existing) } returns existing
+		every { statusHistoryRepository.save(any()) } returns mockk()
 
 		val result = applicationService.update(
 			userId, existing.id,
@@ -57,6 +66,44 @@ class ApplicationServiceTest {
 		assertEquals("Acme", result.company)
 		assertEquals("Berlin", result.location)
 		assertEquals(ApplicationStatus.APPLIED, result.status)
+	}
+
+	@Test
+	fun `update does not record a history entry when the status is unchanged`() {
+		val existing = Application(userId = userId, company = "Acme", role = "Backend Engineer", status = ApplicationStatus.APPLIED)
+		every { applicationRepository.findByIdAndUserId(existing.id, userId) } returns existing
+		every { applicationRepository.save(existing) } returns existing
+
+		applicationService.update(userId, existing.id, UpdateApplicationRequest(status = ApplicationStatus.APPLIED))
+
+		verify(exactly = 0) { statusHistoryRepository.save(any()) }
+	}
+
+	@Test
+	fun `changeStatus updates the application and records history`() {
+		val existing = Application(userId = userId, company = "Acme", role = "Backend Engineer", status = ApplicationStatus.SAVED)
+		every { applicationRepository.findByIdAndUserId(existing.id, userId) } returns existing
+		every { applicationRepository.save(existing) } returns existing
+		val historySlot = slot<ApplicationStatusHistory>()
+		every { statusHistoryRepository.save(capture(historySlot)) } answers { historySlot.captured }
+
+		val result = applicationService.changeStatus(userId, existing.id, ApplicationStatus.APPLIED)
+
+		assertEquals(ApplicationStatus.APPLIED, result.status)
+		assertEquals(ApplicationStatus.APPLIED, historySlot.captured.status)
+	}
+
+	@Test
+	fun `getHistory returns entries ordered by change time`() {
+		val existing = Application(userId = userId, company = "Acme", role = "Backend Engineer")
+		every { applicationRepository.findByIdAndUserId(existing.id, userId) } returns existing
+		val entries = listOf(ApplicationStatusHistory(applicationId = existing.id, status = ApplicationStatus.SAVED))
+		every { statusHistoryRepository.findByApplicationIdOrderByChangedAtAsc(existing.id) } returns entries
+
+		val result = applicationService.getHistory(userId, existing.id)
+
+		assertEquals(1, result.size)
+		assertEquals(ApplicationStatus.SAVED, result[0].status)
 	}
 
 	@Test

--- a/backend/src/test/kotlin/com/nextrole/web/ApplicationControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/ApplicationControllerTest.kt
@@ -3,8 +3,11 @@ package com.nextrole.web
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.nextrole.domain.Application
+import com.nextrole.domain.ApplicationStatus
+import com.nextrole.domain.ApplicationStatusHistory
 import com.nextrole.exception.ApplicationNotFoundException
 import com.nextrole.service.ApplicationService
+import com.nextrole.web.dto.ChangeStatusRequest
 import com.nextrole.web.dto.CreateApplicationRequest
 import io.mockk.every
 import org.junit.jupiter.api.AfterEach
@@ -93,6 +96,33 @@ class ApplicationControllerTest {
 
 		mockMvc.delete("/api/applications/$id").andExpect {
 			status { isNoContent() }
+		}
+	}
+
+	@Test
+	fun `changeStatus returns the updated application`() {
+		val id = UUID.randomUUID()
+		val updated = Application(id = id, userId = userId, company = "Acme", role = "Backend Engineer", status = ApplicationStatus.APPLIED)
+		every { applicationService.changeStatus(userId, id, ApplicationStatus.APPLIED) } returns updated
+
+		mockMvc.post("/api/applications/$id/status") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(ChangeStatusRequest(ApplicationStatus.APPLIED))
+		}.andExpect {
+			status { isOk() }
+			jsonPath("$.status") { value("APPLIED") }
+		}
+	}
+
+	@Test
+	fun `history returns the status timeline`() {
+		val id = UUID.randomUUID()
+		val entries = listOf(ApplicationStatusHistory(applicationId = id, status = ApplicationStatus.SAVED))
+		every { applicationService.getHistory(userId, id) } returns entries
+
+		mockMvc.get("/api/applications/$id/history").andExpect {
+			status { isOk() }
+			jsonPath("$[0].status") { value("SAVED") }
 		}
 	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthPage } from "./pages/AuthPage";
 import { ApplicationsPage } from "./pages/ApplicationsPage";
+import { ApplicationDetailPage } from "./pages/ApplicationDetailPage";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 
 export function App() {
@@ -12,6 +13,14 @@ export function App() {
 				element={
 					<ProtectedRoute>
 						<ApplicationsPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="/applications/:id"
+				element={
+					<ProtectedRoute>
+						<ApplicationDetailPage />
 					</ProtectedRoute>
 				}
 			/>

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -1,13 +1,30 @@
 import { apiClient } from "./client";
 import type {
 	Application,
+	ApplicationStatus,
 	CreateApplicationRequest,
 	Page,
+	StatusHistoryEntry,
 	UpdateApplicationRequest,
 } from "../types/application";
 
 export async function listApplications(): Promise<Page<Application>> {
 	const response = await apiClient.get<Page<Application>>("/api/applications");
+	return response.data;
+}
+
+export async function getApplication(id: string): Promise<Application> {
+	const response = await apiClient.get<Application>(`/api/applications/${id}`);
+	return response.data;
+}
+
+export async function changeApplicationStatus(id: string, status: ApplicationStatus): Promise<Application> {
+	const response = await apiClient.post<Application>(`/api/applications/${id}/status`, { status });
+	return response.data;
+}
+
+export async function getApplicationHistory(id: string): Promise<StatusHistoryEntry[]> {
+	const response = await apiClient.get<StatusHistoryEntry[]>(`/api/applications/${id}/history`);
 	return response.data;
 }
 

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApplicationDetailPage } from "./ApplicationDetailPage";
+import { AuthProvider } from "../context/AuthContext";
+import * as applicationsApi from "../api/applications";
+import type { Application, StatusHistoryEntry } from "../types/application";
+
+vi.mock("../api/applications");
+
+const SAMPLE_APPLICATION: Application = {
+	id: "app-1",
+	company: "Acme Corp",
+	role: "Backend Engineer",
+	location: "Berlin",
+	salaryMin: 70000,
+	salaryMax: 85000,
+	techStack: "Kotlin, Spring Boot",
+	jobDescription: "Build great APIs.",
+	applicationDate: "2026-08-01",
+	status: "APPLIED",
+	notes: null,
+	createdAt: "2026-08-01T00:00:00Z",
+	updatedAt: "2026-08-01T00:00:00Z",
+};
+
+const SAMPLE_HISTORY: StatusHistoryEntry[] = [
+	{ id: "h1", status: "SAVED", changedAt: "2026-07-28T00:00:00Z" },
+	{ id: "h2", status: "APPLIED", changedAt: "2026-08-01T00:00:00Z" },
+];
+
+function renderDetailPage() {
+	localStorage.setItem("nextrole_email", "user@example.com");
+	localStorage.setItem("nextrole_token", "fake-token");
+	return render(
+		<MemoryRouter initialEntries={["/applications/app-1"]}>
+			<AuthProvider>
+				<Routes>
+					<Route path="/applications/:id" element={<ApplicationDetailPage />} />
+				</Routes>
+			</AuthProvider>
+		</MemoryRouter>
+	);
+}
+
+describe("ApplicationDetailPage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+		vi.mocked(applicationsApi.getApplication).mockResolvedValue(SAMPLE_APPLICATION);
+		vi.mocked(applicationsApi.getApplicationHistory).mockResolvedValue(SAMPLE_HISTORY);
+	});
+
+	it("renders the application overview by default", async () => {
+		renderDetailPage();
+
+		expect(await screen.findByRole("heading", { name: "Backend Engineer" })).toBeInTheDocument();
+		expect(screen.getByText("Build great APIs.")).toBeInTheDocument();
+		expect(screen.getByText("Kotlin")).toBeInTheDocument();
+	});
+
+	it("switches to the status history tab", async () => {
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Status History"));
+
+		expect(screen.getAllByText("Saved").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("Applied", { selector: "span" }).length).toBeGreaterThan(0);
+	});
+
+	it("changes the application status", async () => {
+		vi.mocked(applicationsApi.changeApplicationStatus).mockResolvedValue({
+			...SAMPLE_APPLICATION,
+			status: "HR_INTERVIEW",
+		});
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Change stage"));
+		await userEvent.click(screen.getByText("HR Interview"));
+
+		await waitFor(() => {
+			expect(applicationsApi.changeApplicationStatus).toHaveBeenCalledWith("app-1", "HR_INTERVIEW");
+		});
+	});
+});

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+	changeApplicationStatus,
+	getApplication,
+	getApplicationHistory,
+	updateApplication,
+} from "../api/applications";
+import type { Application, ApplicationStatus, CreateApplicationRequest, StatusHistoryEntry } from "../types/application";
+import { AppShell } from "../components/AppShell";
+import { StatusBadge, statusOptions } from "../components/StatusBadge";
+import { ApplicationFormModal } from "../components/ApplicationFormModal";
+
+type Tab = "overview" | "history";
+
+export function ApplicationDetailPage() {
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const [application, setApplication] = useState<Application | null>(null);
+	const [history, setHistory] = useState<StatusHistoryEntry[]>([]);
+	const [tab, setTab] = useState<Tab>("overview");
+	const [editing, setEditing] = useState(false);
+	const [changingStage, setChangingStage] = useState(false);
+
+	async function refresh() {
+		if (!id) return;
+		const [app, hist] = await Promise.all([getApplication(id), getApplicationHistory(id)]);
+		setApplication(app);
+		setHistory(hist);
+	}
+
+	useEffect(() => {
+		refresh();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [id]);
+
+	async function handleUpdate(request: CreateApplicationRequest) {
+		if (!id) return;
+		await updateApplication(id, request);
+		await refresh();
+	}
+
+	async function handleChangeStatus(status: ApplicationStatus) {
+		if (!id) return;
+		await changeApplicationStatus(id, status);
+		setChangingStage(false);
+		await refresh();
+	}
+
+	if (!application) {
+		return (
+			<AppShell>
+				<p style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+			</AppShell>
+		);
+	}
+
+	return (
+		<AppShell>
+			<div>
+				<a
+					href="#"
+					onClick={(e) => {
+						e.preventDefault();
+						navigate("/applications");
+					}}
+					style={{ fontSize: 13, textDecoration: "none", fontWeight: 600 }}
+				>
+					← Back to applications
+				</a>
+			</div>
+
+			<div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", flexWrap: "wrap", gap: 16 }}>
+				<div>
+					<div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+						<h1 style={{ font: "700 26px var(--font-heading)", margin: 0 }}>{application.role}</h1>
+						<StatusBadge status={application.status} />
+					</div>
+					<div style={{ color: "var(--color-text-muted)", fontSize: 14 }}>
+						{application.company}
+						{application.location ? ` · ${application.location}` : ""}
+						{application.salaryMin && application.salaryMax
+							? ` · €${application.salaryMin / 1000}k–${application.salaryMax / 1000}k`
+							: ""}
+					</div>
+				</div>
+				<div style={{ display: "flex", gap: 10, position: "relative" }}>
+					<button
+						onClick={() => setEditing(true)}
+						style={{
+							border: "1px solid var(--color-border)",
+							background: "#fff",
+							borderRadius: 10,
+							padding: "10px 16px",
+							font: "600 13px var(--font-body)",
+							cursor: "pointer",
+						}}
+					>
+						Edit
+					</button>
+					<button
+						onClick={() => setChangingStage((v) => !v)}
+						style={{
+							border: "none",
+							background: "var(--color-accent)",
+							color: "#fff",
+							borderRadius: 10,
+							padding: "10px 16px",
+							font: "600 13px var(--font-body)",
+							cursor: "pointer",
+						}}
+					>
+						Change stage
+					</button>
+					{changingStage && (
+						<div
+							style={{
+								position: "absolute",
+								top: "calc(100% + 8px)",
+								right: 0,
+								background: "#fff",
+								border: "1px solid var(--color-border)",
+								borderRadius: 12,
+								boxShadow: "0 12px 32px oklch(22% 0.014 250 / 0.12)",
+								padding: 8,
+								display: "flex",
+								flexDirection: "column",
+								gap: 2,
+								zIndex: 5,
+								minWidth: 160,
+							}}
+						>
+							{statusOptions().map((opt) => (
+								<button
+									key={opt.value}
+									onClick={() => handleChangeStatus(opt.value)}
+									style={{
+										border: "none",
+										background: opt.value === application.status ? "oklch(96% 0.006 250)" : "transparent",
+										borderRadius: 8,
+										padding: "8px 10px",
+										font: "500 13px var(--font-body)",
+										textAlign: "left",
+										cursor: "pointer",
+									}}
+								>
+									{opt.label}
+								</button>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+
+			<div style={{ display: "flex", gap: 6, borderBottom: "1px solid var(--color-border)" }}>
+				{(["overview", "history"] as Tab[]).map((t) => (
+					<div
+						key={t}
+						onClick={() => setTab(t)}
+						style={{
+							padding: "10px 16px",
+							font: "600 13px var(--font-body)",
+							cursor: "pointer",
+							color: tab === t ? "var(--color-text)" : "var(--color-text-faint)",
+							borderBottom: `2px solid ${tab === t ? "var(--color-accent)" : "transparent"}`,
+						}}
+					>
+						{t === "overview" ? "Overview" : "Status History"}
+					</div>
+				))}
+			</div>
+
+			{tab === "overview" && (
+				<div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 20, alignItems: "start" }}>
+					<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 22 }}>
+						<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 12px" }}>Job description</h3>
+						<p style={{ fontSize: 13.5, lineHeight: 1.7, color: "oklch(30% 0.012 250)", whiteSpace: "pre-line" }}>
+							{application.jobDescription || "No job description saved yet."}
+						</p>
+					</div>
+					<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+						<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
+							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 10px" }}>Tech stack</h3>
+							<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+								{(application.techStack ?? "")
+									.split(",")
+									.map((t) => t.trim())
+									.filter(Boolean)
+									.map((t) => (
+										<span
+											key={t}
+											style={{
+												font: "500 11px var(--font-mono)",
+												background: "oklch(95% 0.006 250)",
+												padding: "4px 9px",
+												borderRadius: 6,
+											}}
+										>
+											{t}
+										</span>
+									))}
+							</div>
+						</div>
+						<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
+							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>Key dates</h3>
+							<div style={{ fontSize: 13, color: "oklch(40% 0.012 250)", display: "flex", flexDirection: "column", gap: 6 }}>
+								<div>Applied: {application.applicationDate ?? "Not applied yet"}</div>
+								<div>Last updated: {new Date(application.updatedAt).toLocaleDateString()}</div>
+							</div>
+						</div>
+						{application.notes && (
+							<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
+								<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>Notes</h3>
+								<p style={{ fontSize: 13, color: "oklch(35% 0.012 250)", lineHeight: 1.6, margin: 0, whiteSpace: "pre-line" }}>
+									{application.notes}
+								</p>
+							</div>
+						)}
+					</div>
+				</div>
+			)}
+
+			{tab === "history" && (
+				<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 24 }}>
+					<div style={{ display: "flex", flexDirection: "column" }}>
+						{history.map((h, i) => (
+							<div key={h.id} style={{ display: "flex", gap: 16 }}>
+								<div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+									<div
+										style={{
+											width: 10,
+											height: 10,
+											borderRadius: "50%",
+											background: i === history.length - 1 ? "var(--color-accent)" : "oklch(80% 0.02 250)",
+											flex: "none",
+										}}
+									/>
+									{i < history.length - 1 && <div style={{ width: 1, flex: 1, background: "oklch(91% 0.007 250)" }} />}
+								</div>
+								<div style={{ paddingBottom: 22 }}>
+									<div style={{ fontWeight: 600, fontSize: 13.5 }}>
+										<StatusBadge status={h.status} />
+									</div>
+									<div style={{ fontSize: 12, color: "var(--color-text-faint)", marginTop: 4 }}>
+										{new Date(h.changedAt).toLocaleString()}
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{editing && <ApplicationFormModal initial={application} onSubmit={handleUpdate} onClose={() => setEditing(false)} />}
+		</AppShell>
+	);
+}

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { createApplication, deleteApplication, listApplications, updateApplication } from "../api/applications";
 import type { Application, CreateApplicationRequest } from "../types/application";
 import { AppShell } from "../components/AppShell";
@@ -7,6 +8,7 @@ import { ApplicationFormModal } from "../components/ApplicationFormModal";
 import { IconButton, PencilIcon, TrashIcon } from "../components/IconButton";
 
 export function ApplicationsPage() {
+	const navigate = useNavigate();
 	const [applications, setApplications] = useState<Application[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [search, setSearch] = useState("");
@@ -117,6 +119,7 @@ export function ApplicationsPage() {
 					{filtered.map((app) => (
 						<div
 							key={app.id}
+							onClick={() => navigate(`/applications/${app.id}`)}
 							style={{
 								display: "grid",
 								gridTemplateColumns: "1.6fr 1.4fr 1fr 1.6fr 1fr 1fr 84px",
@@ -124,6 +127,7 @@ export function ApplicationsPage() {
 								alignItems: "center",
 								borderBottom: "1px solid oklch(95% 0.005 250)",
 								fontSize: 13,
+								cursor: "pointer",
 							}}
 						>
 							<div>
@@ -158,7 +162,10 @@ export function ApplicationsPage() {
 								<StatusBadge status={app.status} />
 							</div>
 							<div style={{ color: "var(--color-text-muted)" }}>{app.applicationDate ?? "—"}</div>
-							<div style={{ display: "flex", gap: 2, justifyContent: "flex-end" }}>
+							<div
+								onClick={(e) => e.stopPropagation()}
+								style={{ display: "flex", gap: 2, justifyContent: "flex-end" }}
+							>
 								<IconButton onClick={() => setEditing(app)} label={`Edit ${app.company}`}>
 									<PencilIcon />
 								</IconButton>

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -38,6 +38,12 @@ export interface CreateApplicationRequest {
 
 export type UpdateApplicationRequest = Partial<CreateApplicationRequest>;
 
+export interface StatusHistoryEntry {
+	id: string;
+	status: ApplicationStatus;
+	changedAt: string;
+}
+
 export interface Page<T> {
 	content: T[];
 	totalElements: number;


### PR DESCRIPTION
Summary

  Adds status-change tracking to applications and a dedicated detail page to view/act on a single application, building directly on the Phase 1 auth + CRUD foundation.

  Backend

  - New ApplicationStatusHistory entity + Flyway migration V2__status_history.sql
  - POST /api/applications/{id}/status — change an application's status, records a history entry
  - GET /api/applications/{id}/history — chronological status timeline
  - An initial history entry is now recorded automatically on application creation
  - Status changes made via the general PATCH /api/applications/{id} endpoint also record history (only when the status actually changes, so no-op updates don't create noise)

  Frontend

  - New ApplicationDetailPage (/applications/:id):
    - Overview tab — job description, tech stack, key dates, notes
    - Status History tab — visual timeline of stage changes
    - "Change stage" dropdown wired to the new status endpoint
    - "Edit" button reuses the existing ApplicationFormModal
  - Applications table rows now navigate to the detail page on click; Edit/Delete icon buttons still work independently (stopPropagation)

  Testing

  - Backend: 21 tests total (added changeStatus/getHistory service tests + two new controller tests)
  - Frontend: 10 tests total (added ApplicationDetailPage coverage: overview render, tab switch, status change)
  - Manually verified end-to-end via docker compose up --build (backend picked up the new migration/endpoints) + npm run dev

  Test plan

  - [x] docker compose up --build — V2 migration applies cleanly on top of V1
  - [x] Click into an application from the table → detail page loads (Overview tab)
  - [x] Switch to Status History tab → shows the timeline, most recent entry highlighted
  - [x] Use "Change stage" → status updates, new entry appears in history
  - [x] Edit from the detail page → changes persist and reflect on Overview
  - [x] ./gradlew test and npm test — all pass
  
  
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 21 22 42" src="https://github.com/user-attachments/assets/f5de311f-5ba7-4aad-b2fc-d137968c3645" />
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 21 22 39" src="https://github.com/user-attachments/assets/1db01e11-b115-441f-9983-182f863dbc87" />
