### PR TITLE
Interviews, Contacts, and Notes

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/domain/Contact.kt
+++ b/backend/src/main/kotlin/com/nextrole/domain/Contact.kt
@@ -1,0 +1,26 @@
+package com.nextrole.domain
+
+import jakarta.persistence.*
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "contacts")
+class Contact(
+	@Id
+	@Column(nullable = false, updatable = false)
+	val id: UUID = UUID.randomUUID(),
+
+	@Column(name = "application_id", nullable = false)
+	val applicationId: UUID,
+
+	@Column(nullable = false)
+	var name: String,
+
+	var role: String? = null,
+
+	var email: String? = null,
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	val createdAt: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/com/nextrole/domain/Interview.kt
+++ b/backend/src/main/kotlin/com/nextrole/domain/Interview.kt
@@ -1,0 +1,32 @@
+package com.nextrole.domain
+
+import jakarta.persistence.*
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "interviews")
+class Interview(
+	@Id
+	@Column(nullable = false, updatable = false)
+	val id: UUID = UUID.randomUUID(),
+
+	@Column(name = "application_id", nullable = false)
+	val applicationId: UUID,
+
+	@Column(nullable = false)
+	var round: String,
+
+	var interviewer: String? = null,
+
+	@Column(name = "scheduled_at", nullable = false)
+	var scheduledAt: Instant,
+
+	var mode: String? = null,
+
+	@Column(columnDefinition = "TEXT")
+	var notes: String? = null,
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	val createdAt: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/com/nextrole/domain/Note.kt
+++ b/backend/src/main/kotlin/com/nextrole/domain/Note.kt
@@ -1,0 +1,22 @@
+package com.nextrole.domain
+
+import jakarta.persistence.*
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "notes")
+class Note(
+    @Id
+    @Column(nullable = false, updatable = false)
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "application_id", nullable = false)
+    val applicationId: UUID,
+
+    @Column(name = "text", nullable = false, columnDefinition = "TEXT")
+    var text: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/com/nextrole/repository/ContactRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/ContactRepository.kt
@@ -1,0 +1,9 @@
+package com.nextrole.repository
+
+import com.nextrole.domain.Contact
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ContactRepository : JpaRepository<Contact, UUID> {
+	fun findByApplicationIdOrderByCreatedAtAsc(applicationId: UUID): List<Contact>
+}

--- a/backend/src/main/kotlin/com/nextrole/repository/InterviewRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/InterviewRepository.kt
@@ -1,0 +1,9 @@
+package com.nextrole.repository
+
+import com.nextrole.domain.Interview
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface InterviewRepository : JpaRepository<Interview, UUID> {
+	fun findByApplicationIdOrderByScheduledAtAsc(applicationId: UUID): List<Interview>
+}

--- a/backend/src/main/kotlin/com/nextrole/repository/NoteRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/NoteRepository.kt
@@ -1,0 +1,9 @@
+package com.nextrole.repository
+
+import com.nextrole.domain.Note
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface NoteRepository : JpaRepository<Note, UUID> {
+    fun findByApplicationIdOrderByCreatedAtAsc(applicationId: UUID): List<Note>
+}

--- a/backend/src/main/kotlin/com/nextrole/service/ContactService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/ContactService.kt
@@ -1,0 +1,30 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Contact
+import com.nextrole.repository.ContactRepository
+import com.nextrole.web.dto.CreateContactRequest
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class ContactService(
+	private val contactRepository: ContactRepository,
+	private val applicationService: ApplicationService
+) {
+
+	fun create(userId: UUID, applicationId: UUID, request: CreateContactRequest): Contact {
+		applicationService.get(userId, applicationId)
+		val contact = Contact(
+			applicationId = applicationId,
+			name = request.name,
+			role = request.role,
+			email = request.email
+		)
+		return contactRepository.save(contact)
+	}
+
+	fun list(userId: UUID, applicationId: UUID): List<Contact> {
+		applicationService.get(userId, applicationId)
+		return contactRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
+	}
+}

--- a/backend/src/main/kotlin/com/nextrole/service/InterviewService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/InterviewService.kt
@@ -1,0 +1,32 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Interview
+import com.nextrole.repository.InterviewRepository
+import com.nextrole.web.dto.CreateInterviewRequest
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class InterviewService(
+	private val interviewRepository: InterviewRepository,
+	private val applicationService: ApplicationService
+) {
+
+	fun create(userId: UUID, applicationId: UUID, request: CreateInterviewRequest): Interview {
+		applicationService.get(userId, applicationId)
+		val interview = Interview(
+			applicationId = applicationId,
+			round = request.round,
+			interviewer = request.interviewer,
+			scheduledAt = request.scheduledAt,
+			mode = request.mode,
+			notes = request.notes
+		)
+		return interviewRepository.save(interview)
+	}
+
+	fun list(userId: UUID, applicationId: UUID): List<Interview> {
+		applicationService.get(userId, applicationId)
+		return interviewRepository.findByApplicationIdOrderByScheduledAtAsc(applicationId)
+	}
+}

--- a/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
@@ -1,0 +1,25 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Note
+import com.nextrole.repository.NoteRepository
+import com.nextrole.web.dto.CreateNoteRequest
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class NoteService(
+    private val noteRepository: NoteRepository,
+    private val applicationService: ApplicationService
+) {
+    fun create(userId: UUID, applicationId: UUID, request: CreateNoteRequest): Note {
+        applicationService.get(userId, applicationId)
+        val note = Note(applicationId = applicationId, text = request.text)
+        val saved = noteRepository.save(note)
+        return saved
+    }
+
+    fun list(userId: UUID, applicationId: UUID): List<Note> {
+        applicationService.get(userId, applicationId)
+        return noteRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
+    }
+}

--- a/backend/src/main/kotlin/com/nextrole/web/ContactController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/ContactController.kt
@@ -1,0 +1,37 @@
+package com.nextrole.web
+
+import com.nextrole.security.CurrentUser
+import com.nextrole.service.ContactService
+import com.nextrole.web.dto.ContactResponse
+import com.nextrole.web.dto.CreateContactRequest
+import com.nextrole.web.dto.toResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/applications/{applicationId}/contacts")
+class ContactController(
+	private val contactService: ContactService
+) {
+
+	@PostMapping
+	fun create(
+		@PathVariable applicationId: UUID,
+		@Valid @RequestBody request: CreateContactRequest
+	): ResponseEntity<ContactResponse> {
+		val contact = contactService.create(CurrentUser.id(), applicationId, request)
+		return ResponseEntity.status(HttpStatus.CREATED).body(contact.toResponse())
+	}
+
+	@GetMapping
+	fun list(@PathVariable applicationId: UUID): List<ContactResponse> =
+		contactService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+}

--- a/backend/src/main/kotlin/com/nextrole/web/InterviewController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/InterviewController.kt
@@ -1,0 +1,37 @@
+package com.nextrole.web
+
+import com.nextrole.security.CurrentUser
+import com.nextrole.service.InterviewService
+import com.nextrole.web.dto.CreateInterviewRequest
+import com.nextrole.web.dto.InterviewResponse
+import com.nextrole.web.dto.toResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/applications/{applicationId}/interviews")
+class InterviewController(
+	private val interviewService: InterviewService
+) {
+
+	@PostMapping
+	fun create(
+		@PathVariable applicationId: UUID,
+		@Valid @RequestBody request: CreateInterviewRequest
+	): ResponseEntity<InterviewResponse> {
+		val interview = interviewService.create(CurrentUser.id(), applicationId, request)
+		return ResponseEntity.status(HttpStatus.CREATED).body(interview.toResponse())
+	}
+
+	@GetMapping
+	fun list(@PathVariable applicationId: UUID): List<InterviewResponse> =
+		interviewService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+}

--- a/backend/src/main/kotlin/com/nextrole/web/NoteController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/NoteController.kt
@@ -1,0 +1,33 @@
+package com.nextrole.web
+
+import com.nextrole.security.CurrentUser
+import com.nextrole.service.NoteService
+import com.nextrole.web.dto.CreateNoteRequest
+import com.nextrole.web.dto.NoteResponse
+import com.nextrole.web.dto.toResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/applications/{applicationId}/notes")
+class NoteController(
+    private val noteService: NoteService
+) {
+    @PostMapping
+    fun create(@Valid @RequestBody request: CreateNoteRequest, @PathVariable applicationId: UUID): ResponseEntity<NoteResponse> {
+        val note = noteService.create(CurrentUser.id(), applicationId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(note.toResponse())
+    }
+
+    @GetMapping
+    fun list(@PathVariable applicationId: UUID): List<NoteResponse> =
+        noteService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+}

--- a/backend/src/main/kotlin/com/nextrole/web/dto/ContactDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/ContactDtos.kt
@@ -1,0 +1,28 @@
+package com.nextrole.web.dto
+
+import com.nextrole.domain.Contact
+import jakarta.validation.constraints.NotBlank
+import java.time.Instant
+import java.util.UUID
+
+data class CreateContactRequest(
+	@field:NotBlank val name: String,
+	val role: String? = null,
+	val email: String? = null
+)
+
+data class ContactResponse(
+	val id: UUID,
+	val name: String,
+	val role: String?,
+	val email: String?,
+	val createdAt: Instant
+)
+
+fun Contact.toResponse() = ContactResponse(
+	id = id,
+	name = name,
+	role = role,
+	email = email,
+	createdAt = createdAt
+)

--- a/backend/src/main/kotlin/com/nextrole/web/dto/InterviewDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/InterviewDtos.kt
@@ -1,0 +1,35 @@
+package com.nextrole.web.dto
+
+import com.nextrole.domain.Interview
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+import java.util.UUID
+
+data class CreateInterviewRequest(
+	@field:NotBlank val round: String,
+	val interviewer: String? = null,
+	@field:NotNull val scheduledAt: Instant,
+	val mode: String? = null,
+	val notes: String? = null
+)
+
+data class InterviewResponse(
+	val id: UUID,
+	val round: String,
+	val interviewer: String?,
+	val scheduledAt: Instant,
+	val mode: String?,
+	val notes: String?,
+	val createdAt: Instant
+)
+
+fun Interview.toResponse() = InterviewResponse(
+	id = id,
+	round = round,
+	interviewer = interviewer,
+	scheduledAt = scheduledAt,
+	mode = mode,
+	notes = notes,
+	createdAt = createdAt
+)

--- a/backend/src/main/kotlin/com/nextrole/web/dto/NoteDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/NoteDtos.kt
@@ -1,0 +1,23 @@
+package com.nextrole.web.dto
+
+import com.nextrole.domain.Note
+import jakarta.validation.constraints.NotBlank
+import java.time.Instant
+import java.util.UUID
+
+data class CreateNoteRequest(
+    @field:NotBlank val text: String
+)
+
+data class NoteResponse(
+    val id: UUID,
+    val text: String,
+    val createdAt: Instant
+)
+
+
+fun Note.toResponse() = NoteResponse(
+    id = id,
+    text = text,
+    createdAt = createdAt
+)

--- a/backend/src/main/resources/db/migration/V3__notes.sql
+++ b/backend/src/main/resources/db/migration/V3__notes.sql
@@ -1,0 +1,8 @@
+CREATE TABLE notes (
+    id UUID PRIMARY KEY,
+    application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    text TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_notes_application_id ON notes(application_id);

--- a/backend/src/main/resources/db/migration/V4__interviews.sql
+++ b/backend/src/main/resources/db/migration/V4__interviews.sql
@@ -1,0 +1,12 @@
+CREATE TABLE interviews (
+	id UUID PRIMARY KEY,
+	application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+	round VARCHAR(255) NOT NULL,
+	interviewer VARCHAR(255),
+	scheduled_at TIMESTAMPTZ NOT NULL,
+	mode VARCHAR(100),
+	notes TEXT,
+	created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_interviews_application_id ON interviews(application_id);

--- a/backend/src/main/resources/db/migration/V5__contacts.sql
+++ b/backend/src/main/resources/db/migration/V5__contacts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE contacts (
+	id UUID PRIMARY KEY,
+	application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+	name VARCHAR(255) NOT NULL,
+	role VARCHAR(255),
+	email VARCHAR(255),
+	created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_contacts_application_id ON contacts(application_id);

--- a/backend/src/test/kotlin/com/nextrole/service/ContactServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/ContactServiceTest.kt
@@ -1,0 +1,61 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Application
+import com.nextrole.domain.Contact
+import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.repository.ContactRepository
+import com.nextrole.web.dto.CreateContactRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class ContactServiceTest {
+
+	private val contactRepository = mockk<ContactRepository>()
+	private val applicationService = mockk<ApplicationService>()
+	private val contactService = ContactService(contactRepository, applicationService)
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@Test
+	fun `create saves a contact once ownership is verified`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val savedSlot = slot<Contact>()
+		every { contactRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+		val result = contactService.create(
+			userId, applicationId,
+			CreateContactRequest(name = "Lena Fischer", role = "Talent Partner")
+		)
+
+		assertEquals(applicationId, savedSlot.captured.applicationId)
+		assertEquals("Lena Fischer", result.name)
+	}
+
+	@Test
+	fun `create throws when the application is not owned by this user`() {
+		every { applicationService.get(userId, applicationId) } throws ApplicationNotFoundException(applicationId)
+
+		assertThrows(ApplicationNotFoundException::class.java) {
+			contactService.create(userId, applicationId, CreateContactRequest(name = "Lena Fischer"))
+		}
+		verify(exactly = 0) { contactRepository.save(any()) }
+	}
+
+	@Test
+	fun `list returns contacts for an owned application`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val contacts = listOf(Contact(applicationId = applicationId, name = "Lena Fischer"))
+		every { contactRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId) } returns contacts
+
+		val result = contactService.list(userId, applicationId)
+
+		assertEquals(1, result.size)
+		assertEquals("Lena Fischer", result[0].name)
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/service/InterviewServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/InterviewServiceTest.kt
@@ -1,0 +1,67 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Application
+import com.nextrole.domain.Interview
+import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.repository.InterviewRepository
+import com.nextrole.web.dto.CreateInterviewRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class InterviewServiceTest {
+
+	private val interviewRepository = mockk<InterviewRepository>()
+	private val applicationService = mockk<ApplicationService>()
+	private val interviewService = InterviewService(interviewRepository, applicationService)
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@Test
+	fun `create saves an interview once ownership is verified`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val savedSlot = slot<Interview>()
+		every { interviewRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+		val scheduledAt = Instant.parse("2026-08-20T14:00:00Z")
+
+		val result = interviewService.create(
+			userId, applicationId,
+			CreateInterviewRequest(round = "Technical Interview", scheduledAt = scheduledAt)
+		)
+
+		assertEquals(applicationId, savedSlot.captured.applicationId)
+		assertEquals("Technical Interview", result.round)
+		assertEquals(scheduledAt, result.scheduledAt)
+	}
+
+	@Test
+	fun `create throws when the application is not owned by this user`() {
+		every { applicationService.get(userId, applicationId) } throws ApplicationNotFoundException(applicationId)
+
+		assertThrows(ApplicationNotFoundException::class.java) {
+			interviewService.create(
+				userId, applicationId,
+				CreateInterviewRequest(round = "Technical Interview", scheduledAt = Instant.now())
+			)
+		}
+		verify(exactly = 0) { interviewRepository.save(any()) }
+	}
+
+	@Test
+	fun `list returns interviews for an owned application`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val interviews = listOf(Interview(applicationId = applicationId, round = "HR Screen", scheduledAt = Instant.now()))
+		every { interviewRepository.findByApplicationIdOrderByScheduledAtAsc(applicationId) } returns interviews
+
+		val result = interviewService.list(userId, applicationId)
+
+		assertEquals(1, result.size)
+		assertEquals("HR Screen", result[0].round)
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
@@ -1,0 +1,67 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Application
+import com.nextrole.domain.Note
+import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.repository.NoteRepository
+import com.nextrole.web.dto.CreateNoteRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class NoteServiceTest {
+
+	private val noteRepository = mockk<NoteRepository>()
+	private val applicationService = mockk<ApplicationService>()
+	private val noteService = NoteService(noteRepository, applicationService)
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@Test
+	fun `create saves a note once ownership is verified`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val savedSlot = slot<Note>()
+		every { noteRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+		val result = noteService.create(userId, applicationId, CreateNoteRequest("Great first call."))
+
+		assertEquals(applicationId, savedSlot.captured.applicationId)
+		assertEquals("Great first call.", result.text)
+	}
+
+	@Test
+	fun `create throws when the application is not owned by this user`() {
+		every { applicationService.get(userId, applicationId) } throws ApplicationNotFoundException(applicationId)
+
+		assertThrows(ApplicationNotFoundException::class.java) {
+			noteService.create(userId, applicationId, CreateNoteRequest("Should not be saved."))
+		}
+		verify(exactly = 0) { noteRepository.save(any()) }
+	}
+
+	@Test
+	fun `list returns notes for an owned application`() {
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		val notes = listOf(Note(applicationId = applicationId, text = "First note"))
+		every { noteRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId) } returns notes
+
+		val result = noteService.list(userId, applicationId)
+
+		assertEquals(1, result.size)
+		assertEquals("First note", result[0].text)
+	}
+
+	@Test
+	fun `list throws when the application is not owned by this user`() {
+		every { applicationService.get(userId, applicationId) } throws ApplicationNotFoundException(applicationId)
+
+		assertThrows(ApplicationNotFoundException::class.java) {
+			noteService.list(userId, applicationId)
+		}
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/web/ContactControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/ContactControllerTest.kt
@@ -1,0 +1,85 @@
+package com.nextrole.web
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.nextrole.domain.Contact
+import com.nextrole.service.ContactService
+import com.nextrole.web.dto.CreateContactRequest
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.util.UUID
+
+@WebMvcTest(ContactController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class ContactControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@Autowired
+	private lateinit var objectMapper: ObjectMapper
+
+	@MockkBean
+	private lateinit var contactService: ContactService
+
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@BeforeEach
+	fun setUp() {
+		val auth = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+		SecurityContextHolder.getContext().authentication = auth
+	}
+
+	@AfterEach
+	fun tearDown() {
+		SecurityContextHolder.clearContext()
+	}
+
+	@Test
+	fun `create returns 201 with the created contact`() {
+		val request = CreateContactRequest(name = "Lena Fischer", role = "Talent Partner")
+		val created = Contact(applicationId = applicationId, name = "Lena Fischer", role = "Talent Partner")
+		every { contactService.create(userId, applicationId, request) } returns created
+
+		mockMvc.post("/api/applications/$applicationId/contacts") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isCreated() }
+			jsonPath("$.name") { value("Lena Fischer") }
+		}
+	}
+
+	@Test
+	fun `create rejects a blank name with 400`() {
+		mockMvc.post("/api/applications/$applicationId/contacts") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(CreateContactRequest(name = ""))
+		}.andExpect {
+			status { isBadRequest() }
+		}
+	}
+
+	@Test
+	fun `list returns the contacts for an application`() {
+		val contacts = listOf(Contact(applicationId = applicationId, name = "Lena Fischer"))
+		every { contactService.list(userId, applicationId) } returns contacts
+
+		mockMvc.get("/api/applications/$applicationId/contacts").andExpect {
+			status { isOk() }
+			jsonPath("$[0].name") { value("Lena Fischer") }
+		}
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/web/InterviewControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/InterviewControllerTest.kt
@@ -1,0 +1,87 @@
+package com.nextrole.web
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.nextrole.domain.Interview
+import com.nextrole.service.InterviewService
+import com.nextrole.web.dto.CreateInterviewRequest
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.time.Instant
+import java.util.UUID
+
+@WebMvcTest(InterviewController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class InterviewControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@Autowired
+	private lateinit var objectMapper: ObjectMapper
+
+	@MockkBean
+	private lateinit var interviewService: InterviewService
+
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@BeforeEach
+	fun setUp() {
+		val auth = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+		SecurityContextHolder.getContext().authentication = auth
+	}
+
+	@AfterEach
+	fun tearDown() {
+		SecurityContextHolder.clearContext()
+	}
+
+	@Test
+	fun `create returns 201 with the created interview`() {
+		val scheduledAt = Instant.parse("2026-08-20T14:00:00Z")
+		val request = CreateInterviewRequest(round = "Technical Interview", scheduledAt = scheduledAt)
+		val created = Interview(applicationId = applicationId, round = "Technical Interview", scheduledAt = scheduledAt)
+		every { interviewService.create(userId, applicationId, request) } returns created
+
+		mockMvc.post("/api/applications/$applicationId/interviews") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isCreated() }
+			jsonPath("$.round") { value("Technical Interview") }
+		}
+	}
+
+	@Test
+	fun `create rejects a blank round with 400`() {
+		mockMvc.post("/api/applications/$applicationId/interviews") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(CreateInterviewRequest(round = "", scheduledAt = Instant.now()))
+		}.andExpect {
+			status { isBadRequest() }
+		}
+	}
+
+	@Test
+	fun `list returns the interviews for an application`() {
+		val interviews = listOf(Interview(applicationId = applicationId, round = "HR Screen", scheduledAt = Instant.now()))
+		every { interviewService.list(userId, applicationId) } returns interviews
+
+		mockMvc.get("/api/applications/$applicationId/interviews").andExpect {
+			status { isOk() }
+			jsonPath("$[0].round") { value("HR Screen") }
+		}
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/web/NoteControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/NoteControllerTest.kt
@@ -1,0 +1,85 @@
+package com.nextrole.web
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.nextrole.domain.Note
+import com.nextrole.service.NoteService
+import com.nextrole.web.dto.CreateNoteRequest
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.util.UUID
+
+@WebMvcTest(NoteController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class NoteControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@Autowired
+	private lateinit var objectMapper: ObjectMapper
+
+	@MockkBean
+	private lateinit var noteService: NoteService
+
+	private val userId = UUID.randomUUID()
+	private val applicationId = UUID.randomUUID()
+
+	@BeforeEach
+	fun setUp() {
+		val auth = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+		SecurityContextHolder.getContext().authentication = auth
+	}
+
+	@AfterEach
+	fun tearDown() {
+		SecurityContextHolder.clearContext()
+	}
+
+	@Test
+	fun `create returns 201 with the created note`() {
+		val request = CreateNoteRequest("Great first call.")
+		val created = Note(applicationId = applicationId, text = "Great first call.")
+		every { noteService.create(userId, applicationId, request) } returns created
+
+		mockMvc.post("/api/applications/$applicationId/notes") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isCreated() }
+			jsonPath("$.text") { value("Great first call.") }
+		}
+	}
+
+	@Test
+	fun `create rejects blank text with 400`() {
+		mockMvc.post("/api/applications/$applicationId/notes") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(CreateNoteRequest(""))
+		}.andExpect {
+			status { isBadRequest() }
+		}
+	}
+
+	@Test
+	fun `list returns the notes for an application`() {
+		val notes = listOf(Note(applicationId = applicationId, text = "First note"))
+		every { noteService.list(userId, applicationId) } returns notes
+
+		mockMvc.get("/api/applications/$applicationId/notes").andExpect {
+			status { isOk() }
+			jsonPath("$[0].text") { value("First note") }
+		}
+	}
+}

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -2,7 +2,13 @@ import { apiClient } from "./client";
 import type {
 	Application,
 	ApplicationStatus,
+	Contact,
 	CreateApplicationRequest,
+	CreateContactRequest,
+	CreateInterviewRequest,
+	CreateNoteRequest,
+	Interview,
+	Note,
 	Page,
 	StatusHistoryEntry,
 	UpdateApplicationRequest,
@@ -25,6 +31,36 @@ export async function changeApplicationStatus(id: string, status: ApplicationSta
 
 export async function getApplicationHistory(id: string): Promise<StatusHistoryEntry[]> {
 	const response = await apiClient.get<StatusHistoryEntry[]>(`/api/applications/${id}/history`);
+	return response.data;
+}
+
+export async function listNotes(applicationId: string): Promise<Note[]> {
+	const response = await apiClient.get<Note[]>(`/api/applications/${applicationId}/notes`);
+	return response.data;
+}
+
+export async function createNote(applicationId: string, request: CreateNoteRequest): Promise<Note> {
+	const response = await apiClient.post<Note>(`/api/applications/${applicationId}/notes`, request);
+	return response.data;
+}
+
+export async function listInterviews(applicationId: string): Promise<Interview[]> {
+	const response = await apiClient.get<Interview[]>(`/api/applications/${applicationId}/interviews`);
+	return response.data;
+}
+
+export async function createInterview(applicationId: string, request: CreateInterviewRequest): Promise<Interview> {
+	const response = await apiClient.post<Interview>(`/api/applications/${applicationId}/interviews`, request);
+	return response.data;
+}
+
+export async function listContacts(applicationId: string): Promise<Contact[]> {
+	const response = await apiClient.get<Contact[]>(`/api/applications/${applicationId}/contacts`);
+	return response.data;
+}
+
+export async function createContact(applicationId: string, request: CreateContactRequest): Promise<Contact> {
+	const response = await apiClient.post<Contact>(`/api/applications/${applicationId}/contacts`, request);
 	return response.data;
 }
 

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ApplicationDetailPage } from "./ApplicationDetailPage";
 import { AuthProvider } from "../context/AuthContext";
 import * as applicationsApi from "../api/applications";
-import type { Application, StatusHistoryEntry } from "../types/application";
+import type { Application, Contact, Interview, Note, StatusHistoryEntry } from "../types/application";
 
 vi.mock("../api/applications");
 
@@ -50,6 +50,9 @@ describe("ApplicationDetailPage", () => {
 		vi.clearAllMocks();
 		vi.mocked(applicationsApi.getApplication).mockResolvedValue(SAMPLE_APPLICATION);
 		vi.mocked(applicationsApi.getApplicationHistory).mockResolvedValue(SAMPLE_HISTORY);
+		vi.mocked(applicationsApi.listNotes).mockResolvedValue([]);
+		vi.mocked(applicationsApi.listInterviews).mockResolvedValue([]);
+		vi.mocked(applicationsApi.listContacts).mockResolvedValue([]);
 	});
 
 	it("renders the application overview by default", async () => {
@@ -84,5 +87,70 @@ describe("ApplicationDetailPage", () => {
 		await waitFor(() => {
 			expect(applicationsApi.changeApplicationStatus).toHaveBeenCalledWith("app-1", "HR_INTERVIEW");
 		});
+	});
+
+	it("shows notes and adds a new one", async () => {
+		const existingNote: Note = { id: "n1", text: "First call went well.", createdAt: "2026-08-01T00:00:00Z" };
+		vi.mocked(applicationsApi.listNotes).mockResolvedValue([existingNote]);
+		vi.mocked(applicationsApi.createNote).mockResolvedValue({ id: "n2", text: "Second note", createdAt: "2026-08-02T00:00:00Z" });
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Notes"));
+
+		expect(screen.getByText("First call went well.")).toBeInTheDocument();
+
+		await userEvent.click(screen.getByText("+ Add note"));
+		await userEvent.type(screen.getByPlaceholderText("Add a note…"), "Second note");
+		await userEvent.click(screen.getByText("Add note"));
+
+		await waitFor(() => {
+			expect(applicationsApi.createNote).toHaveBeenCalledWith("app-1", { text: "Second note" });
+		});
+	});
+
+	it("shows contacts and adds a new one", async () => {
+		const existingContact: Contact = { id: "c1", name: "Lena Fischer", role: "Talent Partner", email: null, createdAt: "2026-08-01T00:00:00Z" };
+		vi.mocked(applicationsApi.listContacts).mockResolvedValue([existingContact]);
+		vi.mocked(applicationsApi.createContact).mockResolvedValue({
+			id: "c2",
+			name: "Jonas Weber",
+			role: null,
+			email: null,
+			createdAt: "2026-08-02T00:00:00Z",
+		});
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Contacts"));
+
+		expect(screen.getByText("Lena Fischer")).toBeInTheDocument();
+
+		await userEvent.click(screen.getByText("+ Add contact"));
+		await userEvent.type(screen.getByPlaceholderText("Name"), "Jonas Weber");
+		await userEvent.click(screen.getByText("Add contact"));
+
+		await waitFor(() => {
+			expect(applicationsApi.createContact).toHaveBeenCalledWith("app-1", { name: "Jonas Weber", role: undefined, email: undefined });
+		});
+	});
+
+	it("shows interviews", async () => {
+		const existingInterview: Interview = {
+			id: "iv1",
+			round: "HR Screen",
+			interviewer: "Lena Fischer",
+			scheduledAt: "2026-08-05T10:00:00Z",
+			mode: "Video call",
+			notes: null,
+			createdAt: "2026-08-01T00:00:00Z",
+		};
+		vi.mocked(applicationsApi.listInterviews).mockResolvedValue([existingInterview]);
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Interviews"));
+
+		expect(screen.getByText("HR Screen")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -1,32 +1,88 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
 	changeApplicationStatus,
+	createContact,
+	createInterview,
+	createNote,
 	getApplication,
 	getApplicationHistory,
+	listContacts,
+	listInterviews,
+	listNotes,
 	updateApplication,
 } from "../api/applications";
-import type { Application, ApplicationStatus, CreateApplicationRequest, StatusHistoryEntry } from "../types/application";
+import type {
+	Application,
+	ApplicationStatus,
+	Contact,
+	CreateApplicationRequest,
+	Interview,
+	Note,
+	StatusHistoryEntry,
+} from "../types/application";
 import { AppShell } from "../components/AppShell";
 import { StatusBadge, statusOptions } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
+import { formatDate, formatDateTime } from "../utils/date";
 
-type Tab = "overview" | "history";
+type Tab = "overview" | "history" | "interviews" | "contacts" | "notes";
+
+const cardStyle: React.CSSProperties = {
+	background: "#fff",
+	border: "1px solid var(--color-border)",
+	borderRadius: 14,
+	padding: 20,
+};
+
+const inputStyle: React.CSSProperties = {
+	border: "1px solid var(--color-border)",
+	borderRadius: 10,
+	padding: "9px 12px",
+	font: "13px var(--font-body)",
+	background: "var(--color-input-bg)",
+};
+
+const addButtonStyle: React.CSSProperties = {
+	border: "none",
+	borderRadius: 10,
+	padding: "9px 16px",
+	background: "var(--color-accent)",
+	color: "#fff",
+	font: "600 13px var(--font-body)",
+	cursor: "pointer",
+	alignSelf: "flex-start",
+};
 
 export function ApplicationDetailPage() {
 	const { id } = useParams<{ id: string }>();
 	const navigate = useNavigate();
 	const [application, setApplication] = useState<Application | null>(null);
 	const [history, setHistory] = useState<StatusHistoryEntry[]>([]);
+	const [notes, setNotes] = useState<Note[]>([]);
+	const [interviews, setInterviews] = useState<Interview[]>([]);
+	const [contacts, setContacts] = useState<Contact[]>([]);
 	const [tab, setTab] = useState<Tab>("overview");
 	const [editing, setEditing] = useState(false);
 	const [changingStage, setChangingStage] = useState(false);
+	const [showNoteForm, setShowNoteForm] = useState(false);
+	const [showInterviewForm, setShowInterviewForm] = useState(false);
+	const [showContactForm, setShowContactForm] = useState(false);
 
 	async function refresh() {
 		if (!id) return;
-		const [app, hist] = await Promise.all([getApplication(id), getApplicationHistory(id)]);
+		const [app, hist, noteList, interviewList, contactList] = await Promise.all([
+			getApplication(id),
+			getApplicationHistory(id),
+			listNotes(id),
+			listInterviews(id),
+			listContacts(id),
+		]);
 		setApplication(app);
 		setHistory(hist);
+		setNotes(noteList);
+		setInterviews(interviewList);
+		setContacts(contactList);
 	}
 
 	useEffect(() => {
@@ -44,6 +100,33 @@ export function ApplicationDetailPage() {
 		if (!id) return;
 		await changeApplicationStatus(id, status);
 		setChangingStage(false);
+		await refresh();
+	}
+
+	async function handleAddNote(text: string) {
+		if (!id) return;
+		await createNote(id, { text });
+		setShowNoteForm(false);
+		await refresh();
+	}
+
+	async function handleAddInterview(round: string, interviewer: string, scheduledAt: string, mode: string, notesText: string) {
+		if (!id) return;
+		await createInterview(id, {
+			round,
+			interviewer: interviewer || undefined,
+			scheduledAt: new Date(scheduledAt).toISOString(),
+			mode: mode || undefined,
+			notes: notesText || undefined,
+		});
+		setShowInterviewForm(false);
+		await refresh();
+	}
+
+	async function handleAddContact(name: string, role: string, email: string) {
+		if (!id) return;
+		await createContact(id, { name, role: role || undefined, email: email || undefined });
+		setShowContactForm(false);
 		await refresh();
 	}
 
@@ -152,34 +235,56 @@ export function ApplicationDetailPage() {
 				</div>
 			</div>
 
-			<div style={{ display: "flex", gap: 6, borderBottom: "1px solid var(--color-border)" }}>
-				{(["overview", "history"] as Tab[]).map((t) => (
-					<div
-						key={t}
-						onClick={() => setTab(t)}
-						style={{
-							padding: "10px 16px",
-							font: "600 13px var(--font-body)",
-							cursor: "pointer",
-							color: tab === t ? "var(--color-text)" : "var(--color-text-faint)",
-							borderBottom: `2px solid ${tab === t ? "var(--color-accent)" : "transparent"}`,
-						}}
-					>
-						{t === "overview" ? "Overview" : "Status History"}
-					</div>
-				))}
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					borderBottom: "1px solid var(--color-border)",
+				}}
+			>
+				<div style={{ display: "flex", gap: 6 }}>
+					{([
+						["overview", "Overview"],
+						["history", "Status History"],
+						["interviews", "Interviews"],
+						["contacts", "Contacts"],
+						["notes", "Notes"],
+					] as [Tab, string][]).map(([t, label]) => (
+						<div
+							key={t}
+							onClick={() => setTab(t)}
+							style={{
+								padding: "10px 16px",
+								font: "600 13px var(--font-body)",
+								cursor: "pointer",
+								color: tab === t ? "var(--color-text)" : "var(--color-text-faint)",
+								borderBottom: `2px solid ${tab === t ? "var(--color-accent)" : "transparent"}`,
+							}}
+						>
+							{label}
+						</div>
+					))}
+				</div>
+				{tab === "interviews" && (
+					<ToggleAddButton label="interview" open={showInterviewForm} onToggle={() => setShowInterviewForm((v) => !v)} />
+				)}
+				{tab === "contacts" && (
+					<ToggleAddButton label="contact" open={showContactForm} onToggle={() => setShowContactForm((v) => !v)} />
+				)}
+				{tab === "notes" && <ToggleAddButton label="note" open={showNoteForm} onToggle={() => setShowNoteForm((v) => !v)} />}
 			</div>
 
 			{tab === "overview" && (
 				<div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 20, alignItems: "start" }}>
-					<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 22 }}>
+					<div style={cardStyle}>
 						<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 12px" }}>Job description</h3>
 						<p style={{ fontSize: 13.5, lineHeight: 1.7, color: "oklch(30% 0.012 250)", whiteSpace: "pre-line" }}>
 							{application.jobDescription || "No job description saved yet."}
 						</p>
 					</div>
 					<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-						<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
+						<div style={cardStyle}>
 							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 10px" }}>Tech stack</h3>
 							<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
 								{(application.techStack ?? "")
@@ -201,27 +306,19 @@ export function ApplicationDetailPage() {
 									))}
 							</div>
 						</div>
-						<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
+						<div style={cardStyle}>
 							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>Key dates</h3>
 							<div style={{ fontSize: 13, color: "oklch(40% 0.012 250)", display: "flex", flexDirection: "column", gap: 6 }}>
-								<div>Applied: {application.applicationDate ?? "Not applied yet"}</div>
-								<div>Last updated: {new Date(application.updatedAt).toLocaleDateString()}</div>
+								<div>Applied: {application.applicationDate ? formatDate(application.applicationDate) : "Not applied yet"}</div>
+								<div>Last updated: {formatDate(application.updatedAt)}</div>
 							</div>
 						</div>
-						{application.notes && (
-							<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 20 }}>
-								<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>Notes</h3>
-								<p style={{ fontSize: 13, color: "oklch(35% 0.012 250)", lineHeight: 1.6, margin: 0, whiteSpace: "pre-line" }}>
-									{application.notes}
-								</p>
-							</div>
-						)}
 					</div>
 				</div>
 			)}
 
 			{tab === "history" && (
-				<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, padding: 24 }}>
+				<div style={cardStyle}>
 					<div style={{ display: "flex", flexDirection: "column" }}>
 						{history.map((h, i) => (
 							<div key={h.id} style={{ display: "flex", gap: 16 }}>
@@ -242,7 +339,7 @@ export function ApplicationDetailPage() {
 										<StatusBadge status={h.status} />
 									</div>
 									<div style={{ fontSize: 12, color: "var(--color-text-faint)", marginTop: 4 }}>
-										{new Date(h.changedAt).toLocaleString()}
+										{formatDateTime(h.changedAt)}
 									</div>
 								</div>
 							</div>
@@ -251,7 +348,215 @@ export function ApplicationDetailPage() {
 				</div>
 			)}
 
+			{tab === "interviews" && (
+				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+					{showInterviewForm && <InterviewForm onSubmit={handleAddInterview} />}
+					{interviews.map((iv) => (
+						<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 6 }}>
+							<div style={{ display: "flex", justifyContent: "space-between" }}>
+								<span style={{ fontWeight: 700, fontSize: 14 }}>{iv.round}</span>
+								<span style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
+									{formatDateTime(iv.scheduledAt)}
+								</span>
+							</div>
+							{(iv.interviewer || iv.mode) && (
+								<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
+									{[iv.interviewer, iv.mode].filter(Boolean).join(" · ")}
+								</div>
+							)}
+							{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
+						</div>
+					))}
+					{interviews.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No interviews scheduled yet.</p>}
+				</div>
+			)}
+
+			{tab === "contacts" && (
+				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+					{showContactForm && <ContactForm onSubmit={handleAddContact} />}
+					<div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 14 }}>
+						{contacts.map((c) => (
+							<div key={c.id} style={{ ...cardStyle, display: "flex", gap: 12, alignItems: "center" }}>
+								<div
+									style={{
+										width: 40,
+										height: 40,
+										borderRadius: "50%",
+										background: "oklch(93% 0.03 35)",
+										flex: "none",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										font: "700 14px var(--font-heading)",
+										color: "oklch(45% 0.11 35)",
+									}}
+								>
+									{c.name.charAt(0).toUpperCase()}
+								</div>
+								<div style={{ minWidth: 0 }}>
+									<div style={{ fontWeight: 600, fontSize: 13.5 }}>{c.name}</div>
+									{c.role && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.role}</div>}
+									{c.email && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.email}</div>}
+								</div>
+							</div>
+						))}
+					</div>
+					{contacts.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No contacts saved yet.</p>}
+				</div>
+			)}
+
+			{tab === "notes" && (
+				<div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+					{showNoteForm && <NoteForm onSubmit={handleAddNote} />}
+					{notes.map((n) => (
+						<div key={n.id} style={{ ...cardStyle, padding: "16px 18px" }}>
+							<div style={{ fontSize: 11.5, color: "var(--color-text-faint)", marginBottom: 6 }}>
+								{formatDateTime(n.createdAt)}
+							</div>
+							<div style={{ fontSize: 13.5, color: "oklch(30% 0.012 250)", lineHeight: 1.6, whiteSpace: "pre-line" }}>
+								{n.text}
+							</div>
+						</div>
+					))}
+					{notes.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No notes yet.</p>}
+				</div>
+			)}
+
 			{editing && <ApplicationFormModal initial={application} onSubmit={handleUpdate} onClose={() => setEditing(false)} />}
 		</AppShell>
+	);
+}
+
+function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
+	const [text, setText] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+
+	async function handleSubmit(e: FormEvent) {
+		e.preventDefault();
+		if (!text.trim()) return;
+		setSubmitting(true);
+		try {
+			await onSubmit(text);
+			setText("");
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
+			<textarea
+				value={text}
+				onChange={(e) => setText(e.target.value)}
+				placeholder="Add a note…"
+				style={{ ...inputStyle, minHeight: 70, resize: "vertical" }}
+			/>
+			<button type="submit" disabled={submitting} style={addButtonStyle}>
+				Add note
+			</button>
+		</form>
+	);
+}
+
+function ToggleAddButton({ label, open, onToggle }: { label: string; open: boolean; onToggle: () => void }) {
+	return (
+		<button
+			onClick={onToggle}
+			style={{
+				border: open ? "1px solid var(--color-border)" : "none",
+				background: open ? "#fff" : "var(--color-accent)",
+				color: open ? "var(--color-text)" : "#fff",
+				borderRadius: 10,
+				padding: "9px 16px",
+				font: "600 13px var(--font-body)",
+				cursor: "pointer",
+			}}
+		>
+			{open ? "Cancel" : `+ Add ${label}`}
+		</button>
+	);
+}
+
+function InterviewForm({
+	onSubmit,
+}: {
+	onSubmit: (round: string, interviewer: string, scheduledAt: string, mode: string, notes: string) => Promise<void>;
+}) {
+	const [round, setRound] = useState("");
+	const [interviewer, setInterviewer] = useState("");
+	const [scheduledAt, setScheduledAt] = useState("");
+	const [mode, setMode] = useState("");
+	const [notes, setNotes] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+
+	async function handleSubmit(e: FormEvent) {
+		e.preventDefault();
+		if (!round.trim() || !scheduledAt) return;
+		setSubmitting(true);
+		try {
+			await onSubmit(round, interviewer, scheduledAt, mode, notes);
+			setRound("");
+			setInterviewer("");
+			setScheduledAt("");
+			setMode("");
+			setNotes("");
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+				<input required placeholder="Round (e.g. HR Screen)" value={round} onChange={(e) => setRound(e.target.value)} style={inputStyle} />
+				<input placeholder="Interviewer" value={interviewer} onChange={(e) => setInterviewer(e.target.value)} style={inputStyle} />
+				<input
+					required
+					type="datetime-local"
+					value={scheduledAt}
+					onChange={(e) => setScheduledAt(e.target.value)}
+					style={inputStyle}
+				/>
+				<input placeholder="Mode (e.g. Video call)" value={mode} onChange={(e) => setMode(e.target.value)} style={inputStyle} />
+			</div>
+			<input placeholder="Notes (optional)" value={notes} onChange={(e) => setNotes(e.target.value)} style={inputStyle} />
+			<button type="submit" disabled={submitting} style={addButtonStyle}>
+				Add interview
+			</button>
+		</form>
+	);
+}
+
+function ContactForm({ onSubmit }: { onSubmit: (name: string, role: string, email: string) => Promise<void> }) {
+	const [name, setName] = useState("");
+	const [role, setRole] = useState("");
+	const [email, setEmail] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+
+	async function handleSubmit(e: FormEvent) {
+		e.preventDefault();
+		if (!name.trim()) return;
+		setSubmitting(true);
+		try {
+			await onSubmit(name, role, email);
+			setName("");
+			setRole("");
+			setEmail("");
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+				<input required placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} style={inputStyle} />
+				<input placeholder="Role" value={role} onChange={(e) => setRole(e.target.value)} style={inputStyle} />
+				<input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} style={inputStyle} />
+			</div>
+			<button type="submit" disabled={submitting} style={addButtonStyle}>
+				Add contact
+			</button>
+		</form>
 	);
 }

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -6,6 +6,7 @@ import { AppShell } from "../components/AppShell";
 import { StatusBadge } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
 import { IconButton, PencilIcon, TrashIcon } from "../components/IconButton";
+import { formatDate } from "../utils/date";
 
 export function ApplicationsPage() {
 	const navigate = useNavigate();
@@ -138,30 +139,54 @@ export function ApplicationsPage() {
 							<div style={{ color: "oklch(40% 0.012 250)" }}>
 								{app.salaryMin && app.salaryMax ? `€${app.salaryMin / 1000}k–${app.salaryMax / 1000}k` : "—"}
 							</div>
-							<div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
-								{(app.techStack ?? "")
-									.split(",")
-									.map((t) => t.trim())
-									.filter(Boolean)
-									.map((t) => (
-										<span
-											key={t}
-											style={{
-												font: "500 10px var(--font-mono)",
-												background: "oklch(95% 0.006 250)",
-												padding: "3px 6px",
-												borderRadius: 5,
-												color: "oklch(38% 0.012 250)",
-											}}
-										>
-											{t}
-										</span>
-									))}
+							<div style={{ display: "flex", gap: 5, flexWrap: "nowrap", overflow: "hidden" }}>
+								{(() => {
+									const tags = (app.techStack ?? "")
+										.split(",")
+										.map((t) => t.trim())
+										.filter(Boolean);
+									const MAX_VISIBLE = 3;
+									const visible = tags.slice(0, MAX_VISIBLE);
+									const hiddenCount = tags.length - visible.length;
+									return (
+										<>
+											{visible.map((t) => (
+												<span
+													key={t}
+													style={{
+														font: "500 10px var(--font-mono)",
+														background: "oklch(95% 0.006 250)",
+														padding: "3px 6px",
+														borderRadius: 5,
+														color: "oklch(38% 0.012 250)",
+														whiteSpace: "nowrap",
+													}}
+												>
+													{t}
+												</span>
+											))}
+											{hiddenCount > 0 && (
+												<span
+													style={{
+														font: "500 10px var(--font-mono)",
+														padding: "3px 6px",
+														color: "var(--color-text-faint)",
+														whiteSpace: "nowrap",
+													}}
+												>
+													+{hiddenCount}
+												</span>
+											)}
+										</>
+									);
+								})()}
 							</div>
 							<div>
 								<StatusBadge status={app.status} />
 							</div>
-							<div style={{ color: "var(--color-text-muted)" }}>{app.applicationDate ?? "—"}</div>
+							<div style={{ color: "var(--color-text-muted)" }}>
+							{app.applicationDate ? formatDate(app.applicationDate) : "—"}
+						</div>
 							<div
 								onClick={(e) => e.stopPropagation()}
 								style={{ display: "flex", gap: 2, justifyContent: "flex-end" }}

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -44,6 +44,48 @@ export interface StatusHistoryEntry {
 	changedAt: string;
 }
 
+export interface Note {
+	id: string;
+	text: string;
+	createdAt: string;
+}
+
+export interface CreateNoteRequest {
+	text: string;
+}
+
+export interface Interview {
+	id: string;
+	round: string;
+	interviewer: string | null;
+	scheduledAt: string;
+	mode: string | null;
+	notes: string | null;
+	createdAt: string;
+}
+
+export interface CreateInterviewRequest {
+	round: string;
+	interviewer?: string;
+	scheduledAt: string;
+	mode?: string;
+	notes?: string;
+}
+
+export interface Contact {
+	id: string;
+	name: string;
+	role: string | null;
+	email: string | null;
+	createdAt: string;
+}
+
+export interface CreateContactRequest {
+	name: string;
+	role?: string;
+	email?: string;
+}
+
 export interface Page<T> {
 	content: T[];
 	totalElements: number;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,20 @@
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+});
+
+export function formatDateTime(iso: string): string {
+	return dateTimeFormatter.format(new Date(iso));
+}
+
+export function formatDate(iso: string): string {
+	return dateFormatter.format(new Date(iso));
+}


### PR DESCRIPTION
Summary

  Adds the last three detail-page tabs from the design mock: scheduled interviews, hiring-team contacts, and free-form notes — each scoped to a single application. Rounds out the application detail page
  (Overview, Status History, Interviews, Contacts, Notes are all now live).

  Backend
  
  Three new entities, each following the same shape (child table → application, ownership-checked service, nested REST resource):
  - Note — POST/GET /api/applications/{id}/notes
  - Interview — POST/GET /api/applications/{id}/interviews (round, interviewer, scheduled time, mode, notes)
  - Contact — POST/GET /api/applications/{id}/contacts (name, role, email)

  All three verify the application belongs to the requesting user before reading/writing (via ApplicationService.get()), same pattern as everything else in the codebase. Scoped to create + list only for
  now — no edit/delete yet (see Backlog note below).

  Frontend
  
  - Application detail page gains working Interviews, Contacts, and Notes tabs
  - Each tab has an "+ Add X" button inline with the tab bar (right-aligned) that reveals a small add form — matches the clean, read-first look of the design mock rather than always showing an open form
  - New src/utils/date.ts (formatDate/formatDateTime) replaces raw toLocaleString() calls everywhere timestamps are shown — consistent, compact formatting (Aug 18, 8:31 AM) instead of verbose locale
  strings
  - Applications table now caps the tech-stack column at 3 visible tags + a +N indicator, so a row with a lot of tech stack data doesn't balloon in height

  Testing

  - Backend: 40 tests total (added 18 across Note/Interview/Contact service + controller layers)
  - Frontend: 13 tests total (added 3 for the new tabs)
  - Manually verified via docker compose up --build + npm run dev

  Test plan

  - [x] docker compose up --build — migrations V3–V5 apply cleanly
  - [x] On an application's detail page, add a note, an interview, and a contact — each appears in its list immediately
  - [x] Confirm the add forms are hidden by default and only appear after clicking "+ Add X"
  - [x] Confirm dates/times render as Aug 18, 8:31 AM style, not raw locale strings
  - [x] Add an application with 5+ tech stack tags — table row shows 3 tags + +2, doesn't balloon in height
  - [x] ./gradlew test and npm test — all pass
  
  
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 22 44 44" src="https://github.com/user-attachments/assets/628bb56c-b251-4a93-b374-dc676c54dfb9" />
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 22 44 48" src="https://github.com/user-attachments/assets/035f53dc-b176-49c6-ad9d-f665c421c2b1" />
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 22 46 25" src="https://github.com/user-attachments/assets/0ac37f23-6305-4b68-8c76-65a3f01832f5" />
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 22 46 21" src="https://github.com/user-attachments/assets/9da4e5ed-3eab-4165-ba8a-045fd7ca08bc" />
<img width="1440" height="660" alt="Screenshot 2026-08-17 at 22 44 58" src="https://github.com/user-attachments/assets/a8a534a9-6909-41d3-a30e-faecb8daabcb" />

