### PR TITLE
Add i18n infrastructure

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,16 +1,18 @@
 {
-  "name": "frontend",
+  "name": "nextrole-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
+      "name": "nextrole-frontend",
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.19.0",
+        "i18next": "^26.3.6",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-i18next": "^17.0.11",
         "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
@@ -117,7 +119,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1708,6 +1709,15 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://locize.com"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -1719,6 +1729,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/indent-string": {
@@ -2339,6 +2377,33 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -2612,7 +2677,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2638,6 +2703,15 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "axios": "^1.19.0",
+    "i18next": "^26.3.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-i18next": "^17.0.11",
     "react-router-dom": "^7.18.2"
   },
   "devDependencies": {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 
 export function AppShell({ children }: { children: ReactNode }) {
 	const { email, logout } = useAuth();
+	const { t } = useTranslation();
 
 	return (
 		<div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
@@ -18,7 +20,7 @@ export function AppShell({ children }: { children: ReactNode }) {
 			>
 				<div style={{ display: "flex", alignItems: "center", gap: 10 }}>
 					<div style={{ width: 28, height: 28, borderRadius: 8, background: "var(--color-accent)" }} />
-					<span style={{ font: "700 17px var(--font-heading)" }}>NextRole</span>
+					<span style={{ font: "700 17px var(--font-heading)" }}>{t("app.name")}</span>
 				</div>
 				<div style={{ display: "flex", alignItems: "center", gap: 14 }}>
 					<span style={{ fontSize: 13, color: "var(--color-text-muted)" }}>{email}</span>
@@ -33,7 +35,7 @@ export function AppShell({ children }: { children: ReactNode }) {
 							cursor: "pointer",
 						}}
 					>
-						Log out
+						{t("nav.logOut")}
 					</button>
 				</div>
 			</header>

--- a/frontend/src/components/ApplicationFormModal.tsx
+++ b/frontend/src/components/ApplicationFormModal.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from "react";
+import { useTranslation } from "react-i18next";
 import type { Application, CreateApplicationRequest } from "../types/application";
 import { statusOptions } from "./StatusBadge";
 
@@ -33,6 +34,7 @@ interface Props {
 }
 
 export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
+	const { t } = useTranslation();
 	const [form, setForm] = useState<CreateApplicationRequest>({
 		company: initial?.company ?? "",
 		role: initial?.role ?? "",
@@ -93,12 +95,12 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 				}}
 			>
 				<h2 style={{ font: "700 18px var(--font-heading)", margin: 0 }}>
-					{initial ? "Edit application" : "New application"}
+					{initial ? t("applicationForm.editTitle") : t("applicationForm.newTitle")}
 				</h2>
 				<form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 					<div style={fieldRowStyle}>
 						<label style={labelStyle}>
-							Company
+							{t("applicationForm.company")}
 							<input
 								required
 								value={form.company}
@@ -107,23 +109,23 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 							/>
 						</label>
 						<label style={labelStyle}>
-							Role
+							{t("applicationForm.role")}
 							<input required value={form.role} onChange={(e) => update("role", e.target.value)} style={inputStyle} />
 						</label>
 					</div>
 					<div style={fieldRowStyle}>
 						<label style={labelStyle}>
-							Location
+							{t("applicationForm.location")}
 							<input value={form.location ?? ""} onChange={(e) => update("location", e.target.value)} style={inputStyle} />
 						</label>
 						<label style={labelStyle}>
-							Tech stack (comma-separated)
+							{t("applicationForm.techStack")}
 							<input value={form.techStack ?? ""} onChange={(e) => update("techStack", e.target.value)} style={inputStyle} />
 						</label>
 					</div>
 					<div style={fieldRowStyle}>
 						<label style={labelStyle}>
-							Salary min
+							{t("applicationForm.salaryMin")}
 							<input
 								type="number"
 								value={form.salaryMin ?? ""}
@@ -132,7 +134,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 							/>
 						</label>
 						<label style={labelStyle}>
-							Salary max
+							{t("applicationForm.salaryMax")}
 							<input
 								type="number"
 								value={form.salaryMax ?? ""}
@@ -143,7 +145,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 					</div>
 					<div style={fieldRowStyle}>
 						<label style={labelStyle}>
-							Application date
+							{t("applicationForm.applicationDate")}
 							<input
 								type="date"
 								value={form.applicationDate ?? ""}
@@ -152,7 +154,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 							/>
 						</label>
 						<label style={labelStyle}>
-							Status
+							{t("applicationForm.status")}
 							<select value={form.status} onChange={(e) => update("status", e.target.value as CreateApplicationRequest["status"])} style={inputStyle}>
 								{statusOptions().map((opt) => (
 									<option key={opt.value} value={opt.value}>
@@ -163,7 +165,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 						</label>
 					</div>
 					<label style={labelStyle}>
-						Notes
+						{t("applicationForm.notes")}
 						<textarea
 							value={form.notes ?? ""}
 							onChange={(e) => update("notes", e.target.value)}
@@ -183,7 +185,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 								cursor: "pointer",
 							}}
 						>
-							Cancel
+							{t("applicationForm.cancel")}
 						</button>
 						<button
 							type="submit"
@@ -199,7 +201,7 @@ export function ApplicationFormModal({ initial, onSubmit, onClose }: Props) {
 								opacity: submitting ? 0.7 : 1,
 							}}
 						>
-							{initial ? "Save changes" : "Create application"}
+							{initial ? t("applicationForm.saveCta") : t("applicationForm.createCta")}
 						</button>
 					</div>
 				</form>

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,17 +1,20 @@
+import { useTranslation } from "react-i18next";
+import i18n from "../i18n/config";
 import type { ApplicationStatus } from "../types/application";
 
-const STAGE_META: Record<ApplicationStatus, { label: string; hue: number }> = {
-	SAVED: { label: "Saved", hue: 230 },
-	APPLIED: { label: "Applied", hue: 200 },
-	HR_INTERVIEW: { label: "HR Interview", hue: 280 },
-	TECHNICAL: { label: "Technical", hue: 310 },
-	FINAL: { label: "Final Round", hue: 20 },
-	OFFER: { label: "Offer", hue: 150 },
-	REJECTED: { label: "Rejected", hue: 0 },
+const STAGE_HUE: Record<ApplicationStatus, number> = {
+	SAVED: 230,
+	APPLIED: 200,
+	HR_INTERVIEW: 280,
+	TECHNICAL: 310,
+	FINAL: 20,
+	OFFER: 150,
+	REJECTED: 0,
 };
 
 export function StatusBadge({ status }: { status: ApplicationStatus }) {
-	const meta = STAGE_META[status];
+	const { t } = useTranslation();
+	const hue = STAGE_HUE[status];
 	return (
 		<span
 			style={{
@@ -19,19 +22,19 @@ export function StatusBadge({ status }: { status: ApplicationStatus }) {
 				fontWeight: 600,
 				padding: "4px 10px",
 				borderRadius: 20,
-				background: `oklch(93% 0.03 ${meta.hue})`,
-				color: `oklch(40% 0.11 ${meta.hue})`,
+				background: `oklch(93% 0.03 ${hue})`,
+				color: `oklch(40% 0.11 ${hue})`,
 				whiteSpace: "nowrap",
 			}}
 		>
-			{meta.label}
+			{t(`status.${status}`)}
 		</span>
 	);
 }
 
 export function statusOptions(): { value: ApplicationStatus; label: string }[] {
-	return (Object.keys(STAGE_META) as ApplicationStatus[]).map((value) => ({
+	return (Object.keys(STAGE_HUE) as ApplicationStatus[]).map((value) => ({
 		value,
-		label: STAGE_META[value].label,
+		label: i18n.t(`status.${value}`),
 	}));
 }

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,16 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "./locales/en.json";
+
+i18n.use(initReactI18next).init({
+	resources: {
+		en: { translation: en },
+	},
+	lng: "en",
+	fallbackLng: "en",
+	interpolation: {
+		escapeValue: false,
+	},
+});
+
+export default i18n;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,0 +1,111 @@
+{
+	"app": {
+		"name": "NextRole"
+	},
+	"nav": {
+		"logOut": "Log out"
+	},
+	"status": {
+		"SAVED": "Saved",
+		"APPLIED": "Applied",
+		"HR_INTERVIEW": "HR Interview",
+		"TECHNICAL": "Technical",
+		"FINAL": "Final Round",
+		"OFFER": "Offer",
+		"REJECTED": "Rejected"
+	},
+	"auth": {
+		"welcomeBackTitle": "Welcome back",
+		"welcomeBackSubtitle": "Sign in to keep tracking your applications.",
+		"createAccountTitle": "Create your account",
+		"createAccountSubtitle": "Start tracking your job search in minutes.",
+		"emailLabel": "Email",
+		"emailPlaceholder": "you@example.com",
+		"passwordLabel": "Password",
+		"signInCta": "Sign in",
+		"createAccountCta": "Create account",
+		"noAccount": "Don't have an account?",
+		"haveAccount": "Already have an account?",
+		"signUpLink": "Sign up",
+		"signInLink": "Sign in",
+		"signupError": "Could not create account. Try a different email.",
+		"loginError": "Invalid email or password."
+	},
+	"applications": {
+		"title": "Applications",
+		"newApplication": "+ New application",
+		"searchPlaceholder": "Search company or role",
+		"loading": "Loading…",
+		"empty": "No applications yet. Add your first one.",
+		"confirmDelete": "Delete this application?",
+		"editAria": "Edit {{company}}",
+		"deleteAria": "Delete {{company}}",
+		"columns": {
+			"companyRole": "Company / Role",
+			"location": "Location",
+			"salary": "Salary",
+			"techStack": "Tech stack",
+			"status": "Status",
+			"applied": "Applied"
+		}
+	},
+	"applicationForm": {
+		"newTitle": "New application",
+		"editTitle": "Edit application",
+		"company": "Company",
+		"role": "Role",
+		"location": "Location",
+		"salaryMin": "Salary min",
+		"salaryMax": "Salary max",
+		"techStack": "Tech stack (comma-separated)",
+		"applicationDate": "Application date",
+		"status": "Status",
+		"notes": "Notes",
+		"cancel": "Cancel",
+		"createCta": "Create application",
+		"saveCta": "Save changes"
+	},
+	"applicationDetail": {
+		"back": "← Back to applications",
+		"edit": "Edit",
+		"changeStage": "Change stage",
+		"tabs": {
+			"overview": "Overview",
+			"history": "Status History",
+			"interviews": "Interviews",
+			"contacts": "Contacts",
+			"notes": "Notes"
+		},
+		"jobDescription": "Job description",
+		"noJobDescription": "No job description saved yet.",
+		"techStack": "Tech stack",
+		"keyDates": "Key dates",
+		"applied": "Applied: {{date}}",
+		"notAppliedYet": "Not applied yet",
+		"lastUpdated": "Last updated: {{date}}",
+		"noInterviews": "No interviews scheduled yet.",
+		"noContacts": "No contacts saved yet.",
+		"noNotes": "No notes yet.",
+		"addInterview": "+ Add interview",
+		"addContact": "+ Add contact",
+		"addNote": "+ Add note",
+		"cancel": "Cancel",
+		"noteForm": {
+			"placeholder": "Add a note…",
+			"submit": "Add note"
+		},
+		"interviewForm": {
+			"roundPlaceholder": "Round (e.g. HR Screen)",
+			"interviewerPlaceholder": "Interviewer",
+			"modePlaceholder": "Mode (e.g. Video call)",
+			"notesPlaceholder": "Notes (optional)",
+			"submit": "Add interview"
+		},
+		"contactForm": {
+			"namePlaceholder": "Name",
+			"rolePlaceholder": "Role",
+			"emailPlaceholder": "Email",
+			"submit": "Add contact"
+		}
+	}
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
+import "./i18n/config";
 import { App } from "./App";
 import { AuthProvider } from "./context/AuthContext";
 

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
 	changeApplicationStatus,
 	createContact,
@@ -55,6 +56,7 @@ const addButtonStyle: React.CSSProperties = {
 };
 
 export function ApplicationDetailPage() {
+	const { t } = useTranslation();
 	const { id } = useParams<{ id: string }>();
 	const navigate = useNavigate();
 	const [application, setApplication] = useState<Application | null>(null);
@@ -133,7 +135,7 @@ export function ApplicationDetailPage() {
 	if (!application) {
 		return (
 			<AppShell>
-				<p style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.loading")}</p>
 			</AppShell>
 		);
 	}
@@ -149,7 +151,7 @@ export function ApplicationDetailPage() {
 					}}
 					style={{ fontSize: 13, textDecoration: "none", fontWeight: 600 }}
 				>
-					← Back to applications
+					{t("applicationDetail.back")}
 				</a>
 			</div>
 
@@ -179,7 +181,7 @@ export function ApplicationDetailPage() {
 							cursor: "pointer",
 						}}
 					>
-						Edit
+						{t("applicationDetail.edit")}
 					</button>
 					<button
 						onClick={() => setChangingStage((v) => !v)}
@@ -193,7 +195,7 @@ export function ApplicationDetailPage() {
 							cursor: "pointer",
 						}}
 					>
-						Change stage
+						{t("applicationDetail.changeStage")}
 					</button>
 					{changingStage && (
 						<div
@@ -245,21 +247,21 @@ export function ApplicationDetailPage() {
 			>
 				<div style={{ display: "flex", gap: 6 }}>
 					{([
-						["overview", "Overview"],
-						["history", "Status History"],
-						["interviews", "Interviews"],
-						["contacts", "Contacts"],
-						["notes", "Notes"],
-					] as [Tab, string][]).map(([t, label]) => (
+						["overview", t("applicationDetail.tabs.overview")],
+						["history", t("applicationDetail.tabs.history")],
+						["interviews", t("applicationDetail.tabs.interviews")],
+						["contacts", t("applicationDetail.tabs.contacts")],
+						["notes", t("applicationDetail.tabs.notes")],
+					] as [Tab, string][]).map(([t2, label]) => (
 						<div
-							key={t}
-							onClick={() => setTab(t)}
+							key={t2}
+							onClick={() => setTab(t2)}
 							style={{
 								padding: "10px 16px",
 								font: "600 13px var(--font-body)",
 								cursor: "pointer",
-								color: tab === t ? "var(--color-text)" : "var(--color-text-faint)",
-								borderBottom: `2px solid ${tab === t ? "var(--color-accent)" : "transparent"}`,
+								color: tab === t2 ? "var(--color-text)" : "var(--color-text-faint)",
+								borderBottom: `2px solid ${tab === t2 ? "var(--color-accent)" : "transparent"}`,
 							}}
 						>
 							{label}
@@ -267,25 +269,39 @@ export function ApplicationDetailPage() {
 					))}
 				</div>
 				{tab === "interviews" && (
-					<ToggleAddButton label="interview" open={showInterviewForm} onToggle={() => setShowInterviewForm((v) => !v)} />
+					<ToggleAddButton
+						addLabel={t("applicationDetail.addInterview")}
+						open={showInterviewForm}
+						onToggle={() => setShowInterviewForm((v) => !v)}
+					/>
 				)}
 				{tab === "contacts" && (
-					<ToggleAddButton label="contact" open={showContactForm} onToggle={() => setShowContactForm((v) => !v)} />
+					<ToggleAddButton
+						addLabel={t("applicationDetail.addContact")}
+						open={showContactForm}
+						onToggle={() => setShowContactForm((v) => !v)}
+					/>
 				)}
-				{tab === "notes" && <ToggleAddButton label="note" open={showNoteForm} onToggle={() => setShowNoteForm((v) => !v)} />}
+				{tab === "notes" && (
+					<ToggleAddButton
+						addLabel={t("applicationDetail.addNote")}
+						open={showNoteForm}
+						onToggle={() => setShowNoteForm((v) => !v)}
+					/>
+				)}
 			</div>
 
 			{tab === "overview" && (
 				<div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 20, alignItems: "start" }}>
 					<div style={cardStyle}>
-						<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 12px" }}>Job description</h3>
+						<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 12px" }}>{t("applicationDetail.jobDescription")}</h3>
 						<p style={{ fontSize: 13.5, lineHeight: 1.7, color: "oklch(30% 0.012 250)", whiteSpace: "pre-line" }}>
-							{application.jobDescription || "No job description saved yet."}
+							{application.jobDescription || t("applicationDetail.noJobDescription")}
 						</p>
 					</div>
 					<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 						<div style={cardStyle}>
-							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 10px" }}>Tech stack</h3>
+							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 10px" }}>{t("applicationDetail.techStack")}</h3>
 							<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
 								{(application.techStack ?? "")
 									.split(",")
@@ -307,10 +323,14 @@ export function ApplicationDetailPage() {
 							</div>
 						</div>
 						<div style={cardStyle}>
-							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>Key dates</h3>
+							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>{t("applicationDetail.keyDates")}</h3>
 							<div style={{ fontSize: 13, color: "oklch(40% 0.012 250)", display: "flex", flexDirection: "column", gap: 6 }}>
-								<div>Applied: {application.applicationDate ? formatDate(application.applicationDate) : "Not applied yet"}</div>
-								<div>Last updated: {formatDate(application.updatedAt)}</div>
+								<div>
+									{application.applicationDate
+										? t("applicationDetail.applied", { date: formatDate(application.applicationDate) })
+										: t("applicationDetail.notAppliedYet")}
+								</div>
+								<div>{t("applicationDetail.lastUpdated", { date: formatDate(application.updatedAt) })}</div>
 							</div>
 						</div>
 					</div>
@@ -367,7 +387,7 @@ export function ApplicationDetailPage() {
 							{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
 						</div>
 					))}
-					{interviews.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No interviews scheduled yet.</p>}
+					{interviews.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noInterviews")}</p>}
 				</div>
 			)}
 
@@ -401,7 +421,7 @@ export function ApplicationDetailPage() {
 							</div>
 						))}
 					</div>
-					{contacts.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No contacts saved yet.</p>}
+					{contacts.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noContacts")}</p>}
 				</div>
 			)}
 
@@ -418,7 +438,7 @@ export function ApplicationDetailPage() {
 							</div>
 						</div>
 					))}
-					{notes.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>No notes yet.</p>}
+					{notes.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noNotes")}</p>}
 				</div>
 			)}
 
@@ -428,6 +448,7 @@ export function ApplicationDetailPage() {
 }
 
 function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
+	const { t } = useTranslation();
 	const [text, setText] = useState("");
 	const [submitting, setSubmitting] = useState(false);
 
@@ -448,17 +469,18 @@ function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
 			<textarea
 				value={text}
 				onChange={(e) => setText(e.target.value)}
-				placeholder="Add a note…"
+				placeholder={t("applicationDetail.noteForm.placeholder")}
 				style={{ ...inputStyle, minHeight: 70, resize: "vertical" }}
 			/>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				Add note
+				{t("applicationDetail.noteForm.submit")}
 			</button>
 		</form>
 	);
 }
 
-function ToggleAddButton({ label, open, onToggle }: { label: string; open: boolean; onToggle: () => void }) {
+function ToggleAddButton({ addLabel, open, onToggle }: { addLabel: string; open: boolean; onToggle: () => void }) {
+	const { t } = useTranslation();
 	return (
 		<button
 			onClick={onToggle}
@@ -472,7 +494,7 @@ function ToggleAddButton({ label, open, onToggle }: { label: string; open: boole
 				cursor: "pointer",
 			}}
 		>
-			{open ? "Cancel" : `+ Add ${label}`}
+			{open ? t("applicationDetail.cancel") : addLabel}
 		</button>
 	);
 }
@@ -482,6 +504,7 @@ function InterviewForm({
 }: {
 	onSubmit: (round: string, interviewer: string, scheduledAt: string, mode: string, notes: string) => Promise<void>;
 }) {
+	const { t } = useTranslation();
 	const [round, setRound] = useState("");
 	const [interviewer, setInterviewer] = useState("");
 	const [scheduledAt, setScheduledAt] = useState("");
@@ -508,8 +531,19 @@ function InterviewForm({
 	return (
 		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
 			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
-				<input required placeholder="Round (e.g. HR Screen)" value={round} onChange={(e) => setRound(e.target.value)} style={inputStyle} />
-				<input placeholder="Interviewer" value={interviewer} onChange={(e) => setInterviewer(e.target.value)} style={inputStyle} />
+				<input
+					required
+					placeholder={t("applicationDetail.interviewForm.roundPlaceholder")}
+					value={round}
+					onChange={(e) => setRound(e.target.value)}
+					style={inputStyle}
+				/>
+				<input
+					placeholder={t("applicationDetail.interviewForm.interviewerPlaceholder")}
+					value={interviewer}
+					onChange={(e) => setInterviewer(e.target.value)}
+					style={inputStyle}
+				/>
 				<input
 					required
 					type="datetime-local"
@@ -517,17 +551,28 @@ function InterviewForm({
 					onChange={(e) => setScheduledAt(e.target.value)}
 					style={inputStyle}
 				/>
-				<input placeholder="Mode (e.g. Video call)" value={mode} onChange={(e) => setMode(e.target.value)} style={inputStyle} />
+				<input
+					placeholder={t("applicationDetail.interviewForm.modePlaceholder")}
+					value={mode}
+					onChange={(e) => setMode(e.target.value)}
+					style={inputStyle}
+				/>
 			</div>
-			<input placeholder="Notes (optional)" value={notes} onChange={(e) => setNotes(e.target.value)} style={inputStyle} />
+			<input
+				placeholder={t("applicationDetail.interviewForm.notesPlaceholder")}
+				value={notes}
+				onChange={(e) => setNotes(e.target.value)}
+				style={inputStyle}
+			/>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				Add interview
+				{t("applicationDetail.interviewForm.submit")}
 			</button>
 		</form>
 	);
 }
 
 function ContactForm({ onSubmit }: { onSubmit: (name: string, role: string, email: string) => Promise<void> }) {
+	const { t } = useTranslation();
 	const [name, setName] = useState("");
 	const [role, setRole] = useState("");
 	const [email, setEmail] = useState("");
@@ -550,12 +595,29 @@ function ContactForm({ onSubmit }: { onSubmit: (name: string, role: string, emai
 	return (
 		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
 			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
-				<input required placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} style={inputStyle} />
-				<input placeholder="Role" value={role} onChange={(e) => setRole(e.target.value)} style={inputStyle} />
-				<input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} style={inputStyle} />
+				<input
+					required
+					placeholder={t("applicationDetail.contactForm.namePlaceholder")}
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					style={inputStyle}
+				/>
+				<input
+					placeholder={t("applicationDetail.contactForm.rolePlaceholder")}
+					value={role}
+					onChange={(e) => setRole(e.target.value)}
+					style={inputStyle}
+				/>
+				<input
+					placeholder={t("applicationDetail.contactForm.emailPlaceholder")}
+					type="email"
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+					style={inputStyle}
+				/>
 			</div>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				Add contact
+				{t("applicationDetail.contactForm.submit")}
 			</button>
 		</form>
 	);

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { createApplication, deleteApplication, listApplications, updateApplication } from "../api/applications";
 import type { Application, CreateApplicationRequest } from "../types/application";
 import { AppShell } from "../components/AppShell";
@@ -9,6 +10,7 @@ import { IconButton, PencilIcon, TrashIcon } from "../components/IconButton";
 import { formatDate } from "../utils/date";
 
 export function ApplicationsPage() {
+	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const [applications, setApplications] = useState<Application[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -49,7 +51,7 @@ export function ApplicationsPage() {
 	}
 
 	async function handleDelete(id: string) {
-		if (!window.confirm("Delete this application?")) return;
+		if (!window.confirm(t("applications.confirmDelete"))) return;
 		await deleteApplication(id);
 		await refresh();
 	}
@@ -57,7 +59,7 @@ export function ApplicationsPage() {
 	return (
 		<AppShell>
 			<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 14 }}>
-				<h1 style={{ font: "700 26px var(--font-heading)", margin: 0 }}>Applications</h1>
+				<h1 style={{ font: "700 26px var(--font-heading)", margin: 0 }}>{t("applications.title")}</h1>
 				<button
 					onClick={() => setCreating(true)}
 					style={{
@@ -70,13 +72,13 @@ export function ApplicationsPage() {
 						cursor: "pointer",
 					}}
 				>
-					+ New application
+					{t("applications.newApplication")}
 				</button>
 			</div>
 
 			<input
 				type="text"
-				placeholder="Search company or role"
+				placeholder={t("applications.searchPlaceholder")}
 				value={search}
 				onChange={(e) => setSearch(e.target.value)}
 				style={{
@@ -90,9 +92,9 @@ export function ApplicationsPage() {
 			/>
 
 			{loading ? (
-				<p style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.loading")}</p>
 			) : filtered.length === 0 ? (
-				<p style={{ color: "var(--color-text-muted)" }}>No applications yet. Add your first one.</p>
+				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.empty")}</p>
 			) : (
 				<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, overflowX: "auto" }}>
 					<div style={{ minWidth: 880 }}>
@@ -109,12 +111,12 @@ export function ApplicationsPage() {
 							borderBottom: "1px solid var(--color-border)",
 						}}
 					>
-						<div>Company / Role</div>
-						<div>Location</div>
-						<div>Salary</div>
-						<div>Tech stack</div>
-						<div>Status</div>
-						<div>Applied</div>
+						<div>{t("applications.columns.companyRole")}</div>
+						<div>{t("applications.columns.location")}</div>
+						<div>{t("applications.columns.salary")}</div>
+						<div>{t("applications.columns.techStack")}</div>
+						<div>{t("applications.columns.status")}</div>
+						<div>{t("applications.columns.applied")}</div>
 						<div />
 					</div>
 					{filtered.map((app) => (
@@ -191,10 +193,14 @@ export function ApplicationsPage() {
 								onClick={(e) => e.stopPropagation()}
 								style={{ display: "flex", gap: 2, justifyContent: "flex-end" }}
 							>
-								<IconButton onClick={() => setEditing(app)} label={`Edit ${app.company}`}>
+								<IconButton onClick={() => setEditing(app)} label={t("applications.editAria", { company: app.company })}>
 									<PencilIcon />
 								</IconButton>
-								<IconButton onClick={() => handleDelete(app.id)} label={`Delete ${app.company}`} variant="danger">
+								<IconButton
+									onClick={() => handleDelete(app.id)}
+									label={t("applications.deleteAria", { company: app.company })}
+									variant="danger"
+								>
 									<TrashIcon />
 								</IconButton>
 							</div>

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 
 const inputStyle: React.CSSProperties = {
@@ -20,6 +21,7 @@ const labelStyle: React.CSSProperties = {
 };
 
 export function AuthPage() {
+	const { t } = useTranslation();
 	const [isSignup, setIsSignup] = useState(false);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
@@ -40,7 +42,7 @@ export function AuthPage() {
 			}
 			navigate("/applications");
 		} catch {
-			setError(isSignup ? "Could not create account. Try a different email." : "Invalid email or password.");
+			setError(isSignup ? t("auth.signupError") : t("auth.loginError"));
 		} finally {
 			setSubmitting(false);
 		}
@@ -71,30 +73,30 @@ export function AuthPage() {
 				<div style={{ flex: 1, padding: "56px 48px", display: "flex", flexDirection: "column", gap: 28 }}>
 					<div style={{ display: "flex", alignItems: "center", gap: 10 }}>
 						<div style={{ width: 32, height: 32, borderRadius: 9, background: "var(--color-accent)" }} />
-						<span style={{ font: "700 18px var(--font-heading)" }}>NextRole</span>
+						<span style={{ font: "700 18px var(--font-heading)" }}>{t("app.name")}</span>
 					</div>
 					<div>
 						<h1 style={{ font: "700 28px var(--font-heading)", margin: "0 0 8px" }}>
-							{isSignup ? "Create your account" : "Welcome back"}
+							{isSignup ? t("auth.createAccountTitle") : t("auth.welcomeBackTitle")}
 						</h1>
 						<p style={{ margin: 0, color: "var(--color-text-muted)", fontSize: 14 }}>
-							{isSignup ? "Start tracking your job search in minutes." : "Sign in to keep tracking your applications."}
+							{isSignup ? t("auth.createAccountSubtitle") : t("auth.welcomeBackSubtitle")}
 						</p>
 					</div>
 					<form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 						<label style={labelStyle}>
-							Email
+							{t("auth.emailLabel")}
 							<input
 								type="email"
 								required
-								placeholder="you@example.com"
+								placeholder={t("auth.emailPlaceholder")}
 								value={email}
 								onChange={(e) => setEmail(e.target.value)}
 								style={inputStyle}
 							/>
 						</label>
 						<label style={labelStyle}>
-							Password
+							{t("auth.passwordLabel")}
 							<input
 								type="password"
 								required
@@ -121,11 +123,11 @@ export function AuthPage() {
 								opacity: submitting ? 0.7 : 1,
 							}}
 						>
-							{isSignup ? "Create account" : "Sign in"}
+							{isSignup ? t("auth.createAccountCta") : t("auth.signInCta")}
 						</button>
 					</form>
 					<p style={{ margin: 0, fontSize: 13, color: "var(--color-text-muted)" }}>
-						{isSignup ? "Already have an account?" : "Don't have an account?"}{" "}
+						{isSignup ? t("auth.haveAccount") : t("auth.noAccount")}{" "}
 						<a
 							href="#"
 							onClick={(e) => {
@@ -135,7 +137,7 @@ export function AuthPage() {
 							}}
 							style={{ fontWeight: 600, textDecoration: "none" }}
 						>
-							{isSignup ? "Sign in" : "Sign up"}
+							{isSignup ? t("auth.signInLink") : t("auth.signUpLink")}
 						</a>
 					</p>
 				</div>
@@ -158,7 +160,7 @@ export function AuthPage() {
 							borderRadius: 8,
 						}}
 					>
-						NextRole
+						{t("app.name")}
 					</span>
 				</div>
 			</div>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,2 @@
 import "@testing-library/jest-dom/vitest";
+import "../i18n/config";


### PR DESCRIPTION
Summary

  Sets up react-i18next and extracts every hardcoded UI string into en.json, ahead of adding German and Turkish support. No new user-facing behavior — the app should look and read identically to before,
  just backed by a translation layer instead of literal strings.

  Why now

  Discussed doing this before more phases (Dashboard, Analytics, JD Analyzer) pile on more hardcoded text. Extraction now, while the surface area is still small (6 components), is cheap. Retrofitting
  after several more feature phases would mean a much larger sweep later.

  What's in this PR

  - react-i18next + i18next installed
  - src/i18n/config.ts — initializes with English resources, en as default/fallback
  - src/i18n/locales/en.json — all strings from AuthPage, AppShell, ApplicationsPage, ApplicationDetailPage, ApplicationFormModal, and StatusBadge's status labels, organized by feature namespace (auth,
  applications, applicationForm, applicationDetail, status, nav, app), with interpolation for dynamic values (e.g. "Edit {{company}}")
  - Every component switched from hardcoded strings to useTranslation() + t()
  - Test setup initializes i18n so RTL renders translated text correctly

  What's NOT in this PR

  - German (de.json) / Turkish (tr.json) translations — infrastructure only, content comes later
  - A language switcher UI — no point building one with only English populated; add once real translations exist

  Testing

  - tsc clean
  - All 13 existing frontend tests pass unchanged (translated English strings match the original hardcoded text exactly, so no test updates were needed)
  - Production build (vite build) succeeds

  Test plan
  
  - [ ] Click through every screen (auth, applications table, application detail + all 5 tabs, create/edit modal) — visually identical to before this PR
  - [ ] npm test — all pass
  - [ ] npm run build — succeeds