### PR TITLE
Calendar

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/repository/InterviewRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/InterviewRepository.kt
@@ -19,4 +19,13 @@ interface InterviewRepository : JpaRepository<Interview, UUID> {
 		"""
 	)
 	fun findUpcomingByUserId(@Param("userId") userId: UUID, @Param("from") from: Instant): List<Interview>
+
+	@Query(
+		"""
+		SELECT i FROM Interview i
+		WHERE i.applicationId IN (SELECT a.id FROM Application a WHERE a.userId = :userId)
+		ORDER BY i.scheduledAt ASC
+		"""
+	)
+	fun findAllByUserId(@Param("userId") userId: UUID): List<Interview>
 }

--- a/backend/src/main/kotlin/com/nextrole/service/CalendarService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/CalendarService.kt
@@ -1,0 +1,28 @@
+package com.nextrole.service
+
+import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.InterviewRepository
+import com.nextrole.web.dto.UpcomingInterviewResponse
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class CalendarService(
+	private val applicationRepository: ApplicationRepository,
+	private val interviewRepository: InterviewRepository
+) {
+
+	fun getInterviews(userId: UUID): List<UpcomingInterviewResponse> {
+		val applicationsById = applicationRepository.findByUserId(userId).associateBy { it.id }
+		return interviewRepository.findAllByUserId(userId).mapNotNull { interview ->
+			val application = applicationsById[interview.applicationId] ?: return@mapNotNull null
+			UpcomingInterviewResponse(
+				applicationId = interview.applicationId,
+				company = application.company,
+				role = application.role,
+				round = interview.round,
+				scheduledAt = interview.scheduledAt
+			)
+		}
+	}
+}

--- a/backend/src/main/kotlin/com/nextrole/web/CalendarController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/CalendarController.kt
@@ -1,0 +1,19 @@
+package com.nextrole.web
+
+import com.nextrole.security.CurrentUser
+import com.nextrole.service.CalendarService
+import com.nextrole.web.dto.UpcomingInterviewResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/calendar")
+class CalendarController(
+	private val calendarService: CalendarService
+) {
+
+	@GetMapping("/interviews")
+	fun interviews(): List<UpcomingInterviewResponse> =
+		calendarService.getInterviews(CurrentUser.id())
+}

--- a/backend/src/test/kotlin/com/nextrole/service/CalendarServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/CalendarServiceTest.kt
@@ -1,0 +1,46 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Application
+import com.nextrole.domain.Interview
+import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.InterviewRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CalendarServiceTest {
+
+	private val applicationRepository = mockk<ApplicationRepository>()
+	private val interviewRepository = mockk<InterviewRepository>()
+	private val calendarService = CalendarService(applicationRepository, interviewRepository)
+	private val userId = UUID.randomUUID()
+
+	@Test
+	fun `maps every interview to its application's company and role`() {
+		val app = Application(userId = userId, company = "Acme", role = "Engineer")
+		val pastInterview = Interview(applicationId = app.id, round = "HR Screen", scheduledAt = Instant.parse("2026-01-01T10:00:00Z"))
+		val futureInterview = Interview(applicationId = app.id, round = "Technical", scheduledAt = Instant.parse("2026-12-01T10:00:00Z"))
+		every { applicationRepository.findByUserId(userId) } returns listOf(app)
+		every { interviewRepository.findAllByUserId(userId) } returns listOf(pastInterview, futureInterview)
+
+		val result = calendarService.getInterviews(userId)
+
+		assertEquals(2, result.size)
+		assertEquals("Acme", result[0].company)
+		assertEquals("HR Screen", result[0].round)
+	}
+
+	@Test
+	fun `skips interviews whose application no longer exists`() {
+		val orphanInterview = Interview(applicationId = UUID.randomUUID(), round = "HR Screen", scheduledAt = Instant.now())
+		every { applicationRepository.findByUserId(userId) } returns emptyList()
+		every { interviewRepository.findAllByUserId(userId) } returns listOf(orphanInterview)
+
+		val result = calendarService.getInterviews(userId)
+
+		assertEquals(0, result.size)
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/web/CalendarControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/CalendarControllerTest.kt
@@ -1,0 +1,60 @@
+package com.nextrole.web
+
+import com.ninjasquad.springmockk.MockkBean
+import com.nextrole.service.CalendarService
+import com.nextrole.web.dto.UpcomingInterviewResponse
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.Instant
+import java.util.UUID
+
+@WebMvcTest(CalendarController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class CalendarControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@MockkBean
+	private lateinit var calendarService: CalendarService
+
+	private val userId = UUID.randomUUID()
+
+	@BeforeEach
+	fun setUp() {
+		val auth = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+		SecurityContextHolder.getContext().authentication = auth
+	}
+
+	@AfterEach
+	fun tearDown() {
+		SecurityContextHolder.clearContext()
+	}
+
+	@Test
+	fun `interviews returns every interview across all applications`() {
+		every { calendarService.getInterviews(userId) } returns listOf(
+			UpcomingInterviewResponse(
+				applicationId = UUID.randomUUID(),
+				company = "Acme",
+				role = "Engineer",
+				round = "HR Screen",
+				scheduledAt = Instant.parse("2026-01-01T10:00:00Z")
+			)
+		)
+
+		mockMvc.get("/api/calendar/interviews").andExpect {
+			status { isOk() }
+			jsonPath("$[0].company") { value("Acme") }
+		}
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthPage } from "./pages/AuthPage";
 import { DashboardPage } from "./pages/DashboardPage";
+import { CalendarPage } from "./pages/CalendarPage";
 import { ApplicationsPage } from "./pages/ApplicationsPage";
 import { ApplicationDetailPage } from "./pages/ApplicationDetailPage";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -14,6 +15,14 @@ export function App() {
 				element={
 					<ProtectedRoute>
 						<DashboardPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="/calendar"
+				element={
+					<ProtectedRoute>
+						<CalendarPage />
 					</ProtectedRoute>
 				}
 			/>

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,0 +1,7 @@
+import { apiClient } from "./client";
+import type { UpcomingInterview } from "../types/dashboard";
+
+export async function getCalendarInterviews(): Promise<UpcomingInterview[]> {
+	const response = await apiClient.get<UpcomingInterview[]>("/api/calendar/interviews");
+	return response.data;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -11,6 +11,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
 	{ path: "/dashboard", labelKey: "nav_links.dashboard" },
 	{ path: "/applications", labelKey: "nav_links.applications" },
+	{ path: "/calendar", labelKey: "nav_links.calendar" },
 ];
 
 const COLLAPSED_KEY = "nextrole_sidebar_collapsed";

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,22 @@
 		"applications": "Applications",
 		"calendar": "Calendar"
 	},
+	"calendar": {
+		"title": "Calendar",
+		"previousMonth": "Previous month",
+		"nextMonth": "Next month",
+		"viewUpcoming": "View upcoming",
+		"noInterviewsOnDay": "No interviews on this day.",
+		"weekdays": {
+			"sun": "Sun",
+			"mon": "Mon",
+			"tue": "Tue",
+			"wed": "Wed",
+			"thu": "Thu",
+			"fri": "Fri",
+			"sat": "Sat"
+		}
+	},
 	"dashboard": {
 		"title": "Dashboard",
 		"subtitle": "{{count}} active applications",

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { CalendarPage } from "./CalendarPage";
+import { AuthProvider } from "../context/AuthContext";
+import * as calendarApi from "../api/calendar";
+import type { UpcomingInterview } from "../types/dashboard";
+
+vi.mock("../api/calendar");
+
+function renderCalendar() {
+	localStorage.setItem("nextrole_email", "user@example.com");
+	localStorage.setItem("nextrole_token", "fake-token");
+	return render(
+		<MemoryRouter initialEntries={["/calendar"]}>
+			<AuthProvider>
+				<Routes>
+					<Route path="/calendar" element={<CalendarPage />} />
+					<Route path="/applications/:id" element={<div>Application detail</div>} />
+				</Routes>
+			</AuthProvider>
+		</MemoryRouter>
+	);
+}
+
+describe("CalendarPage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	it("shows an empty state when there are no interviews", async () => {
+		vi.mocked(calendarApi.getCalendarInterviews).mockResolvedValue([]);
+		renderCalendar();
+
+		expect(await screen.findByText("No interviews scheduled.")).toBeInTheDocument();
+	});
+
+	it("lists upcoming interviews and navigates to the application on click", async () => {
+		const future: UpcomingInterview = {
+			applicationId: "app-1",
+			company: "Acme Corp",
+			role: "Backend Engineer",
+			round: "HR Screen",
+			scheduledAt: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+		};
+		vi.mocked(calendarApi.getCalendarInterviews).mockResolvedValue([future]);
+		renderCalendar();
+
+		await userEvent.click(await screen.findByText("Acme Corp"));
+
+		expect(await screen.findByText("Application detail")).toBeInTheDocument();
+	});
+
+	it("shows a past interview when clicking the day it happened on", async () => {
+		const past = new Date();
+		past.setHours(past.getHours() - 2);
+		const pastInterview: UpcomingInterview = {
+			applicationId: "app-2",
+			company: "Legacy Corp",
+			role: "Engineer",
+			round: "Technical",
+			scheduledAt: past.toISOString(),
+		};
+		vi.mocked(calendarApi.getCalendarInterviews).mockResolvedValue([pastInterview]);
+		renderCalendar();
+
+		await screen.findByText("No interviews scheduled.");
+		const key = `${past.getFullYear()}-${String(past.getMonth() + 1).padStart(2, "0")}-${String(past.getDate()).padStart(2, "0")}`;
+		await userEvent.click(screen.getByTestId(`calendar-day-${key}`));
+
+		expect(await screen.findByText("Legacy Corp")).toBeInTheDocument();
+		expect(screen.getByText("View upcoming")).toBeInTheDocument();
+	});
+
+	it("navigates between months", async () => {
+		vi.mocked(calendarApi.getCalendarInterviews).mockResolvedValue([]);
+		renderCalendar();
+
+		const headings = await screen.findAllByRole("heading", { level: 3 });
+		const initialLabel = headings[0].textContent;
+		await userEvent.click(screen.getByLabelText("Next month"));
+
+		const nextLabel = screen.getAllByRole("heading", { level: 3 })[0].textContent;
+		expect(nextLabel).not.toBe(initialLabel);
+	});
+});

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { getCalendarInterviews } from "../api/calendar";
+import type { UpcomingInterview } from "../types/dashboard";
+import { AppShell } from "../components/AppShell";
+import { formatDateTime } from "../utils/date";
+
+const cardStyle: React.CSSProperties = {
+	background: "#fff",
+	border: "1px solid var(--color-border)",
+	borderRadius: 14,
+	padding: 22,
+};
+
+const WEEKDAY_KEYS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+function dateKey(d: Date): string {
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function CalendarPage() {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const [interviews, setInterviews] = useState<UpcomingInterview[]>([]);
+	const [viewDate, setViewDate] = useState(() => {
+		const now = new Date();
+		return new Date(now.getFullYear(), now.getMonth(), 1);
+	});
+	const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
+
+	useEffect(() => {
+		getCalendarInterviews().then(setInterviews);
+	}, []);
+
+	const interviewsByDay = useMemo(() => {
+		const map = new Map<string, UpcomingInterview[]>();
+		for (const iv of interviews) {
+			const key = dateKey(new Date(iv.scheduledAt));
+			const list = map.get(key) ?? [];
+			list.push(iv);
+			map.set(key, list);
+		}
+		return map;
+	}, [interviews]);
+
+	const upcomingInterviews = useMemo(() => {
+		const now = Date.now();
+		return interviews
+			.filter((iv) => new Date(iv.scheduledAt).getTime() >= now)
+			.sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime())
+			.slice(0, 8);
+	}, [interviews]);
+
+	const selectedDayInterviews = useMemo(() => {
+		if (!selectedDateKey) return [];
+		return (interviewsByDay.get(selectedDateKey) ?? [])
+			.slice()
+			.sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime());
+	}, [interviewsByDay, selectedDateKey]);
+
+	const today = new Date();
+	const year = viewDate.getFullYear();
+	const month = viewDate.getMonth();
+	const firstOfMonth = new Date(year, month, 1);
+	const daysInMonth = new Date(year, month + 1, 0).getDate();
+	const leadingBlanks = firstOfMonth.getDay();
+
+	const monthLabel = viewDate.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+
+	function changeMonth(delta: number) {
+		setViewDate(new Date(year, month + delta, 1));
+	}
+
+	const cells: { num: number | null; key: string | null; isToday: boolean; hasEvent: boolean }[] = [];
+	for (let i = 0; i < leadingBlanks; i++) {
+		cells.push({ num: null, key: null, isToday: false, hasEvent: false });
+	}
+	for (let day = 1; day <= daysInMonth; day++) {
+		const d = new Date(year, month, day);
+		const key = dateKey(d);
+		cells.push({
+			num: day,
+			key,
+			isToday: dateKey(today) === key,
+			hasEvent: interviewsByDay.has(key),
+		});
+	}
+
+	return (
+		<AppShell>
+			<h1 style={{ font: "700 26px var(--font-heading)", margin: 0 }}>{t("calendar.title")}</h1>
+
+			<div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr", gap: 20, alignItems: "start" }}>
+				<div style={cardStyle}>
+					<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+						<h3 style={{ font: "700 15px var(--font-heading)", margin: 0 }}>{monthLabel}</h3>
+						<div style={{ display: "flex", gap: 6 }}>
+							<button onClick={() => changeMonth(-1)} style={navButtonStyle} aria-label={t("calendar.previousMonth")}>
+								‹
+							</button>
+							<button onClick={() => changeMonth(1)} style={navButtonStyle} aria-label={t("calendar.nextMonth")}>
+								›
+							</button>
+						</div>
+					</div>
+					<div
+						style={{
+							display: "grid",
+							gridTemplateColumns: "repeat(7, 1fr)",
+							gap: 6,
+							fontSize: 11,
+							fontWeight: 600,
+							color: "var(--color-text-faint)",
+							textTransform: "uppercase",
+							marginBottom: 8,
+						}}
+					>
+						{WEEKDAY_KEYS.map((key) => (
+							<div key={key}>{t(`calendar.weekdays.${key}`)}</div>
+						))}
+					</div>
+					<div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 6 }}>
+						{cells.map((cell, i) => {
+							const isSelected = cell.key !== null && cell.key === selectedDateKey;
+							return (
+								<div
+									key={cell.key ?? `blank-${i}`}
+									data-testid={cell.key ? `calendar-day-${cell.key}` : undefined}
+									onClick={() => {
+										if (!cell.key) return;
+										setSelectedDateKey((prev) => (prev === cell.key ? null : cell.key));
+									}}
+									style={{
+										aspectRatio: "1",
+										borderRadius: 10,
+										border: isSelected ? "2px solid var(--color-accent)" : "1px solid var(--color-border)",
+										background: cell.isToday ? "oklch(93% 0.03 35)" : "#fff",
+										padding: 6,
+										display: "flex",
+										flexDirection: "column",
+										gap: 4,
+										visibility: cell.num === null ? "hidden" : "visible",
+										cursor: cell.num === null ? "default" : "pointer",
+									}}
+								>
+									<span
+										style={{
+											fontSize: 12,
+											fontWeight: 600,
+											color: cell.isToday ? "oklch(42% 0.11 35)" : "var(--color-text)",
+										}}
+									>
+										{cell.num}
+									</span>
+									{cell.hasEvent && (
+										<div style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--color-accent)" }} />
+									)}
+								</div>
+							);
+						})}
+					</div>
+				</div>
+
+				<div style={cardStyle}>
+					<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+						<h3 style={{ font: "700 15px var(--font-heading)", margin: 0 }}>
+							{selectedDateKey
+								? new Date(`${selectedDateKey}T00:00:00`).toLocaleDateString("en-US", {
+										month: "short",
+										day: "numeric",
+										year: "numeric",
+									})
+								: t("dashboard.upcomingInterviews")}
+						</h3>
+						{selectedDateKey && (
+							<a
+								href="#"
+								onClick={(e) => {
+									e.preventDefault();
+									setSelectedDateKey(null);
+								}}
+								style={{ fontSize: 12, textDecoration: "none", fontWeight: 600 }}
+							>
+								{t("calendar.viewUpcoming")}
+							</a>
+						)}
+					</div>
+					<div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+						{(selectedDateKey ? selectedDayInterviews : upcomingInterviews).map((iv) => (
+							<div
+								key={`${iv.applicationId}-${iv.scheduledAt}`}
+								onClick={() => navigate(`/applications/${iv.applicationId}`)}
+								style={{
+									display: "flex",
+									alignItems: "center",
+									gap: 14,
+									padding: "12px 4px",
+									borderBottom: "1px solid oklch(94% 0.005 250)",
+									cursor: "pointer",
+								}}
+							>
+								<div style={{ flex: 1, minWidth: 0 }}>
+									<div style={{ fontWeight: 600, fontSize: 13.5 }}>{iv.company}</div>
+									<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>{iv.round}</div>
+								</div>
+								<div style={{ fontSize: 12, color: "var(--color-text-faint)" }}>{formatDateTime(iv.scheduledAt)}</div>
+							</div>
+						))}
+						{selectedDateKey
+							? selectedDayInterviews.length === 0 && (
+									<p style={{ color: "var(--color-text-muted)", margin: 0 }}>{t("calendar.noInterviewsOnDay")}</p>
+								)
+							: upcomingInterviews.length === 0 && (
+									<p style={{ color: "var(--color-text-muted)", margin: 0 }}>{t("dashboard.noUpcomingInterviews")}</p>
+								)}
+					</div>
+				</div>
+			</div>
+		</AppShell>
+	);
+}
+
+const navButtonStyle: React.CSSProperties = {
+	width: 28,
+	height: 28,
+	borderRadius: 8,
+	border: "1px solid var(--color-border)",
+	background: "#fff",
+	color: "var(--color-text-muted)",
+	cursor: "pointer",
+	fontSize: 14,
+};


### PR DESCRIPTION
Summary

  Completes Phase 4 with a month-view calendar, wrapping up the last screen from the original phase scope (Dashboard and Board view already merged in PR #5).

  Backend

  - GET /api/calendar/interviews — every interview across all of a user's applications (not just the "next 5 upcoming" the dashboard endpoint returns), needed so the calendar can render markers on past
  months too, not just look forward
  - New InterviewRepository.findAllByUserId JPQL query; CalendarService maps interviews to their application's company/role, reusing the existing UpcomingInterviewResponse shape from the dashboard work

  Frontend 

  - Calendar screen (/calendar, added to sidebar nav): real month grid with prev/next navigation, today highlighted, a dot marker on any day with a scheduled interview
  - Click any day (past or future) to filter the side panel to that day's interviews specifically; "View upcoming" link returns to the default upcoming-interviews list
  - Reuses the same list-item pattern as the Dashboard's upcoming-interviews panel (click an interview → jump to its application)

  Testing

  - Backend: 51 tests total (2 new: CalendarServiceTest, CalendarControllerTest)
  - Frontend: 30 tests total (5 new: empty state, upcoming-interview click-through, month navigation, day-click filtering including past dates)

  Test plan

  - [x] docker compose up --build — no new migrations, just new endpoint code
  - [x] Open Calendar from the sidebar → current month renders with today highlighted
  - [x] Navigate to a month with a scheduled interview → dot appears on the correct day
  - [x] Click that day → side panel filters to just that day's interview(s)
  - [x] Click a day in the past with an interview → it still shows (calendar isn't upcoming-only)
  - [x] Click "View upcoming" → panel returns to the default upcoming list
  - [x] ./gradlew test and npm test — all pass

<img width="1440" height="660" alt="Screenshot 2026-08-18 at 18 20 08" src="https://github.com/user-attachments/assets/c43124ba-2c01-4709-999a-107b2c5542b0" />
<img width="1440" height="660" alt="Screenshot 2026-08-18 at 18 20 01" src="https://github.com/user-attachments/assets/11b350a7-6226-444f-8c66-d925c2d47831" />
