### PR TITLE
UI polish: toasts, close-button cohesion, detail-page rework

### DIFF
--- a/frontend/src/components/ApplicationBoard.tsx
+++ b/frontend/src/components/ApplicationBoard.tsx
@@ -4,6 +4,7 @@ import type { Application, ApplicationStatus } from "../types/application";
 import { statusHue, statusOptions } from "./StatusBadge";
 import { formatSalaryRange } from "../utils/currency";
 import { formatLocation } from "../utils/workMode";
+import { PlusIcon } from "./IconButton";
 
 const cardStyle: React.CSSProperties = {
 	background: "#fff",
@@ -88,17 +89,19 @@ export function ApplicationBoard({ applications, onStatusChange, onAddToStatus }
 								onClick={() => onAddToStatus(col.status)}
 								aria-label={`Add application to ${col.label}`}
 								style={{
+									display: "inline-flex",
+									alignItems: "center",
+									justifyContent: "center",
+									width: 24,
+									height: 24,
 									border: "none",
 									background: "transparent",
 									color: "var(--color-text-faint)",
 									cursor: "pointer",
-									font: "600 15px var(--font-body)",
-									lineHeight: 1,
-									padding: "2px 4px",
 									borderRadius: 6,
 								}}
 							>
-								+
+								<PlusIcon />
 							</button>
 						)}
 					</div>
@@ -153,13 +156,26 @@ export function ApplicationBoard({ applications, onStatusChange, onAddToStatus }
 									borderRadius: 12,
 									padding: "18px 14px",
 									background: "transparent",
-									color: "var(--color-text-faint)",
 									cursor: "pointer",
-									font: "600 20px var(--font-body)",
-									lineHeight: 1,
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
 								}}
 							>
-								+
+								<span
+									style={{
+										width: 28,
+										height: 28,
+										borderRadius: "50%",
+										background: "var(--color-accent)",
+										color: "#fff",
+										display: "inline-flex",
+										alignItems: "center",
+										justifyContent: "center",
+									}}
+								>
+									<PlusIcon />
+								</span>
 							</button>
 						)}
 					</div>

--- a/frontend/src/components/ApplicationFormModal.tsx
+++ b/frontend/src/components/ApplicationFormModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { Application, ApplicationStatus, CreateApplicationRequest } from "../types/application";
 import { statusOptions } from "./StatusBadge";
 import { CURRENCY_OPTIONS } from "../utils/currency";
+import { CloseButton } from "./CloseButton";
 
 const inputStyle: React.CSSProperties = {
 	border: "1px solid var(--color-border)",
@@ -110,8 +111,10 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 					gap: 16,
 					maxHeight: "90vh",
 					overflowY: "auto",
+					position: "relative",
 				}}
 			>
+				<CloseButton onClick={onClose} />
 				<h2 style={{ font: "700 18px var(--font-heading)", margin: 0 }}>
 					{initial ? t("applicationForm.editTitle") : t("applicationForm.newTitle")}
 				</h2>
@@ -212,20 +215,6 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 						/>
 					</label>
 					<div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 6 }}>
-						<button
-							type="button"
-							onClick={onClose}
-							style={{
-								border: "1px solid var(--color-border)",
-								background: "#fff",
-								borderRadius: 10,
-								padding: "10px 16px",
-								font: "600 13px var(--font-body)",
-								cursor: "pointer",
-							}}
-						>
-							{t("applicationForm.cancel")}
-						</button>
 						<button
 							type="submit"
 							disabled={submitting}

--- a/frontend/src/components/CloseButton.tsx
+++ b/frontend/src/components/CloseButton.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import { XIcon } from "./IconButton";
+
+export function CloseButton({ onClick }: { onClick: () => void }) {
+	const { t } = useTranslation();
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-label={t("applicationForm.cancel")}
+			title={t("applicationForm.cancel")}
+			style={{
+				position: "absolute",
+				top: 10,
+				right: 10,
+				width: 24,
+				height: 24,
+				borderRadius: "50%",
+				border: "none",
+				background: "oklch(95% 0.006 250)",
+				color: "var(--color-text-muted)",
+				cursor: "pointer",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+			}}
+		>
+			<XIcon />
+		</button>
+	);
+}

--- a/frontend/src/components/IconButton.tsx
+++ b/frontend/src/components/IconButton.tsx
@@ -38,6 +38,24 @@ export function PencilIcon() {
 	);
 }
 
+export function PlusIcon() {
+	return (
+		<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+			<path d="M12 5v14" />
+			<path d="M5 12h14" />
+		</svg>
+	);
+}
+
+export function XIcon() {
+	return (
+		<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+			<path d="M18 6 6 18" />
+			<path d="M6 6l12 12" />
+		</svg>
+	);
+}
+
 export function TrashIcon() {
 	return (
 		<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,0 +1,98 @@
+import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+
+type ToastVariant = "success" | "error";
+
+interface Toast {
+	id: number;
+	message: string;
+	variant: ToastVariant;
+}
+
+interface ToastContextValue {
+	showToast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const AUTO_DISMISS_MS = 4000;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+
+	const dismissToast = useCallback((id: number) => {
+		setToasts((prev) => prev.filter((toast) => toast.id !== id));
+	}, []);
+
+	const showToast = useCallback(
+		(message: string, variant: ToastVariant = "success") => {
+			const id = Date.now() + Math.random();
+			setToasts((prev) => [...prev, { id, message, variant }]);
+			setTimeout(() => dismissToast(id), AUTO_DISMISS_MS);
+		},
+		[dismissToast]
+	);
+
+	return (
+		<ToastContext.Provider value={{ showToast }}>
+			{children}
+			<div
+				style={{
+					position: "fixed",
+					bottom: 24,
+					right: 24,
+					display: "flex",
+					flexDirection: "column",
+					gap: 10,
+					zIndex: 100,
+				}}
+			>
+				{toasts.map((toast) => (
+					<div
+						key={toast.id}
+						style={{
+							background: toast.variant === "success" ? "oklch(45% 0.14 150)" : "oklch(50% 0.19 25)",
+							color: "#fff",
+							padding: "12px 14px 12px 18px",
+							borderRadius: 10,
+							font: "500 13px var(--font-body)",
+							boxShadow: "0 8px 24px oklch(22% 0.014 250 / 0.25)",
+							minWidth: 220,
+							maxWidth: 360,
+							display: "flex",
+							alignItems: "center",
+							gap: 10,
+						}}
+					>
+						<span style={{ flex: 1 }}>{toast.message}</span>
+						<button
+							type="button"
+							onClick={() => dismissToast(toast.id)}
+							aria-label="Dismiss"
+							style={{
+								border: "none",
+								background: "transparent",
+								color: "#fff",
+								opacity: 0.75,
+								cursor: "pointer",
+								fontSize: 15,
+								lineHeight: 1,
+								padding: 2,
+								flex: "none",
+							}}
+						>
+							×
+						</button>
+					</div>
+				))}
+			</div>
+		</ToastContext.Provider>
+	);
+}
+
+export function useToast(): ToastContextValue {
+	const context = useContext(ToastContext);
+	if (!context) {
+		throw new Error("useToast must be used within a ToastProvider");
+	}
+	return context;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -83,6 +83,13 @@
 		"confirmDelete": "Delete this application?",
 		"editAria": "Edit {{company}}",
 		"deleteAria": "Delete {{company}}",
+		"toasts": {
+			"created": "Application created",
+			"updated": "Application updated",
+			"deleted": "Application deleted",
+			"statusChanged": "Status updated",
+			"error": "Something went wrong. Please try again."
+		},
 		"columns": {
 			"companyRole": "Company / Role",
 			"location": "Location",
@@ -137,10 +144,15 @@
 		"noInterviews": "No interviews scheduled yet.",
 		"noContacts": "No contacts saved yet.",
 		"noNotes": "No notes yet.",
-		"addInterview": "+ Add interview",
-		"addContact": "+ Add contact",
-		"addNote": "+ Add note",
+		"addInterview": "Add interview",
+		"addContact": "Add contact",
+		"addNote": "Add note",
 		"cancel": "Cancel",
+		"toasts": {
+			"noteAdded": "Note added",
+			"interviewAdded": "Interview added",
+			"contactAdded": "Contact added"
+		},
 		"noteForm": {
 			"placeholder": "Add a note…",
 			"submit": "Add note"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,12 +5,15 @@ import "./index.css";
 import "./i18n/config";
 import { App } from "./App";
 import { AuthProvider } from "./context/AuthContext";
+import { ToastProvider } from "./context/ToastContext";
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
 		<BrowserRouter>
 			<AuthProvider>
-				<App />
+				<ToastProvider>
+					<App />
+				</ToastProvider>
 			</AuthProvider>
 		</BrowserRouter>
 	</StrictMode>

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ApplicationDetailPage } from "./ApplicationDetailPage";
 import { AuthProvider } from "../context/AuthContext";
+import { ToastProvider } from "../context/ToastContext";
 import * as applicationsApi from "../api/applications";
 import type { Application, Contact, Interview, Note, StatusHistoryEntry } from "../types/application";
 
@@ -38,9 +39,11 @@ function renderDetailPage() {
 	return render(
 		<MemoryRouter initialEntries={["/applications/app-1"]}>
 			<AuthProvider>
-				<Routes>
-					<Route path="/applications/:id" element={<ApplicationDetailPage />} />
-				</Routes>
+				<ToastProvider>
+					<Routes>
+						<Route path="/applications/:id" element={<ApplicationDetailPage />} />
+					</Routes>
+				</ToastProvider>
 			</AuthProvider>
 		</MemoryRouter>
 	);
@@ -102,9 +105,9 @@ describe("ApplicationDetailPage", () => {
 
 		expect(screen.getByText("First call went well.")).toBeInTheDocument();
 
-		await userEvent.click(screen.getByText("+ Add note"));
+		await userEvent.click(screen.getByLabelText("Add note"));
 		await userEvent.type(screen.getByPlaceholderText("Add a note…"), "Second note");
-		await userEvent.click(screen.getByText("Add note"));
+		await userEvent.click(screen.getByRole("button", { name: "Add note" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.createNote).toHaveBeenCalledWith("app-1", { text: "Second note" });
@@ -128,9 +131,9 @@ describe("ApplicationDetailPage", () => {
 
 		expect(screen.getByText("Lena Fischer")).toBeInTheDocument();
 
-		await userEvent.click(screen.getByText("+ Add contact"));
+		await userEvent.click(screen.getByLabelText("Add contact"));
 		await userEvent.type(screen.getByPlaceholderText("Name"), "Jonas Weber");
-		await userEvent.click(screen.getByText("Add contact"));
+		await userEvent.click(screen.getByRole("button", { name: "Add contact" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.createContact).toHaveBeenCalledWith("app-1", { name: "Jonas Weber", role: undefined, email: undefined });

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -25,6 +25,9 @@ import type {
 import { AppShell } from "../components/AppShell";
 import { StatusBadge, statusOptions } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
+import { CloseButton } from "../components/CloseButton";
+import { PlusIcon } from "../components/IconButton";
+import { useToast } from "../context/ToastContext";
 import { formatDate, formatDateTime } from "../utils/date";
 import { formatSalaryRange } from "../utils/currency";
 import { formatLocation } from "../utils/workMode";
@@ -36,6 +39,54 @@ const cardStyle: React.CSSProperties = {
 	border: "1px solid var(--color-border)",
 	borderRadius: 14,
 	padding: 20,
+};
+
+const emptyStateStyle: React.CSSProperties = {
+	border: "1px dashed var(--color-border)",
+	borderRadius: 14,
+	padding: "48px 20px",
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	justifyContent: "center",
+	gap: 12,
+	color: "var(--color-text-muted)",
+	fontSize: 13.5,
+	cursor: "pointer",
+};
+
+const emptyStateIconStyle: React.CSSProperties = {
+	width: 32,
+	height: 32,
+	borderRadius: "50%",
+	background: "var(--color-accent)",
+	color: "#fff",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+};
+
+const addTileStyle: React.CSSProperties = {
+	border: "1px dashed var(--color-border)",
+	borderRadius: 14,
+	padding: "14px 20px",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	color: "var(--color-text-muted)",
+	cursor: "pointer",
+};
+
+const addTileIconStyle: React.CSSProperties = {
+	width: 24,
+	height: 24,
+	borderRadius: "50%",
+	background: "var(--color-accent)",
+	color: "#fff",
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	flex: "none",
 };
 
 const inputStyle: React.CSSProperties = {
@@ -54,13 +105,14 @@ const addButtonStyle: React.CSSProperties = {
 	color: "#fff",
 	font: "600 13px var(--font-body)",
 	cursor: "pointer",
-	alignSelf: "flex-start",
+	alignSelf: "flex-end",
 };
 
 export function ApplicationDetailPage() {
 	const { t } = useTranslation();
 	const { id } = useParams<{ id: string }>();
 	const navigate = useNavigate();
+	const { showToast } = useToast();
 	const [application, setApplication] = useState<Application | null>(null);
 	const [history, setHistory] = useState<StatusHistoryEntry[]>([]);
 	const [notes, setNotes] = useState<Note[]>([]);
@@ -96,42 +148,71 @@ export function ApplicationDetailPage() {
 
 	async function handleUpdate(request: CreateApplicationRequest) {
 		if (!id) return;
-		await updateApplication(id, request);
-		await refresh();
+		try {
+			await updateApplication(id, request);
+			showToast(t("applications.toasts.updated"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	async function handleChangeStatus(status: ApplicationStatus) {
 		if (!id) return;
-		await changeApplicationStatus(id, status);
-		setChangingStage(false);
-		await refresh();
+		try {
+			await changeApplicationStatus(id, status);
+			setChangingStage(false);
+			showToast(t("applications.toasts.statusChanged"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
+		}
 	}
 
 	async function handleAddNote(text: string) {
 		if (!id) return;
-		await createNote(id, { text });
-		setShowNoteForm(false);
-		await refresh();
+		try {
+			await createNote(id, { text });
+			setShowNoteForm(false);
+			showToast(t("applicationDetail.toasts.noteAdded"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	async function handleAddInterview(round: string, interviewer: string, scheduledAt: string, mode: string, notesText: string) {
 		if (!id) return;
-		await createInterview(id, {
-			round,
-			interviewer: interviewer || undefined,
-			scheduledAt: new Date(scheduledAt).toISOString(),
-			mode: mode || undefined,
-			notes: notesText || undefined,
-		});
-		setShowInterviewForm(false);
-		await refresh();
+		try {
+			await createInterview(id, {
+				round,
+				interviewer: interviewer || undefined,
+				scheduledAt: new Date(scheduledAt).toISOString(),
+				mode: mode || undefined,
+				notes: notesText || undefined,
+			});
+			setShowInterviewForm(false);
+			showToast(t("applicationDetail.toasts.interviewAdded"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	async function handleAddContact(name: string, role: string, email: string) {
 		if (!id) return;
-		await createContact(id, { name, role: role || undefined, email: email || undefined });
-		setShowContactForm(false);
-		await refresh();
+		try {
+			await createContact(id, { name, role: role || undefined, email: email || undefined });
+			setShowContactForm(false);
+			showToast(t("applicationDetail.toasts.contactAdded"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	if (!application) {
@@ -272,27 +353,6 @@ export function ApplicationDetailPage() {
 						</div>
 					))}
 				</div>
-				{tab === "interviews" && (
-					<ToggleAddButton
-						addLabel={t("applicationDetail.addInterview")}
-						open={showInterviewForm}
-						onToggle={() => setShowInterviewForm((v) => !v)}
-					/>
-				)}
-				{tab === "contacts" && (
-					<ToggleAddButton
-						addLabel={t("applicationDetail.addContact")}
-						open={showContactForm}
-						onToggle={() => setShowContactForm((v) => !v)}
-					/>
-				)}
-				{tab === "notes" && (
-					<ToggleAddButton
-						addLabel={t("applicationDetail.addNote")}
-						open={showNoteForm}
-						onToggle={() => setShowNoteForm((v) => !v)}
-					/>
-				)}
 			</div>
 
 			{tab === "overview" && (
@@ -347,22 +407,22 @@ export function ApplicationDetailPage() {
 						{history.map((h, i) => (
 							<div key={h.id} style={{ display: "flex", gap: 16 }}>
 								<div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-									<div
-										style={{
-											width: 10,
-											height: 10,
-											borderRadius: "50%",
-											background: i === history.length - 1 ? "var(--color-accent)" : "oklch(80% 0.02 250)",
-											flex: "none",
-										}}
-									/>
-									{i < history.length - 1 && <div style={{ width: 1, flex: 1, background: "oklch(91% 0.007 250)" }} />}
-								</div>
-								<div style={{ paddingBottom: 22 }}>
-									<div style={{ fontWeight: 600, fontSize: 13.5 }}>
-										<StatusBadge status={h.status} />
+									<div style={{ height: 20, display: "flex", alignItems: "center", flex: "none" }}>
+										<div
+											style={{
+												width: 10,
+												height: 10,
+												borderRadius: "50%",
+												background: i === history.length - 1 ? "var(--color-accent)" : "oklch(80% 0.02 250)",
+												flex: "none",
+											}}
+										/>
 									</div>
-									<div style={{ fontSize: 12, color: "var(--color-text-faint)", marginTop: 4 }}>
+									{i < history.length - 1 && <div style={{ width: 1, flex: 1, background: "oklch(88% 0.007 250)" }} />}
+								</div>
+								<div style={{ paddingBottom: i < history.length - 1 ? 26 : 0 }}>
+									<div style={{ fontWeight: 700, fontSize: 14 }}>{t(`status.${h.status}`)}</div>
+									<div style={{ fontSize: 12, color: "var(--color-text-faint)", marginTop: 3 }}>
 										{formatDateTime(h.changedAt)}
 									</div>
 								</div>
@@ -374,7 +434,6 @@ export function ApplicationDetailPage() {
 
 			{tab === "interviews" && (
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-					{showInterviewForm && <InterviewForm onSubmit={handleAddInterview} />}
 					{interviews.map((iv) => (
 						<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 6 }}>
 							<div style={{ display: "flex", justifyContent: "space-between" }}>
@@ -391,13 +450,36 @@ export function ApplicationDetailPage() {
 							{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
 						</div>
 					))}
-					{interviews.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noInterviews")}</p>}
+					{showInterviewForm && (
+						<InterviewForm onSubmit={handleAddInterview} onClose={() => setShowInterviewForm(false)} />
+					)}
+					{interviews.length > 0 && !showInterviewForm && (
+						<div
+							style={addTileStyle}
+							onClick={() => setShowInterviewForm(true)}
+							role="button"
+							aria-label={t("applicationDetail.addInterview")}
+							title={t("applicationDetail.addInterview")}
+						>
+							<div style={addTileIconStyle}>
+								<PlusIcon />
+							</div>
+						</div>
+					)}
+					{interviews.length === 0 && !showInterviewForm && (
+						<div style={emptyStateStyle} onClick={() => setShowInterviewForm(true)}>
+							<div style={emptyStateIconStyle}>
+								<PlusIcon />
+							</div>
+							{t("applicationDetail.noInterviews")}
+						</div>
+					)}
 				</div>
 			)}
 
 			{tab === "contacts" && (
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-					{showContactForm && <ContactForm onSubmit={handleAddContact} />}
+					{contacts.length > 0 && (
 					<div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 14 }}>
 						{contacts.map((c) => (
 							<div key={c.id} style={{ ...cardStyle, display: "flex", gap: 12, alignItems: "center" }}>
@@ -424,14 +506,39 @@ export function ApplicationDetailPage() {
 								</div>
 							</div>
 						))}
+						{showContactForm ? (
+							<ContactForm onSubmit={handleAddContact} onClose={() => setShowContactForm(false)} />
+						) : (
+							<div
+								style={addTileStyle}
+								onClick={() => setShowContactForm(true)}
+								role="button"
+								aria-label={t("applicationDetail.addContact")}
+								title={t("applicationDetail.addContact")}
+							>
+								<div style={addTileIconStyle}>
+									<PlusIcon />
+								</div>
+							</div>
+						)}
 					</div>
-					{contacts.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noContacts")}</p>}
+					)}
+					{contacts.length === 0 && showContactForm && (
+						<ContactForm onSubmit={handleAddContact} onClose={() => setShowContactForm(false)} />
+					)}
+					{contacts.length === 0 && !showContactForm && (
+						<div style={emptyStateStyle} onClick={() => setShowContactForm(true)}>
+							<div style={emptyStateIconStyle}>
+								<PlusIcon />
+							</div>
+							{t("applicationDetail.noContacts")}
+						</div>
+					)}
 				</div>
 			)}
 
 			{tab === "notes" && (
-				<div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-					{showNoteForm && <NoteForm onSubmit={handleAddNote} />}
+				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 					{notes.map((n) => (
 						<div key={n.id} style={{ ...cardStyle, padding: "16px 18px" }}>
 							<div style={{ fontSize: 11.5, color: "var(--color-text-faint)", marginBottom: 6 }}>
@@ -442,7 +549,28 @@ export function ApplicationDetailPage() {
 							</div>
 						</div>
 					))}
-					{notes.length === 0 && <p style={{ color: "var(--color-text-muted)" }}>{t("applicationDetail.noNotes")}</p>}
+					{showNoteForm && <NoteForm onSubmit={handleAddNote} onClose={() => setShowNoteForm(false)} />}
+					{notes.length > 0 && !showNoteForm && (
+						<div
+							style={addTileStyle}
+							onClick={() => setShowNoteForm(true)}
+							role="button"
+							aria-label={t("applicationDetail.addNote")}
+							title={t("applicationDetail.addNote")}
+						>
+							<div style={addTileIconStyle}>
+								<PlusIcon />
+							</div>
+						</div>
+					)}
+					{notes.length === 0 && !showNoteForm && (
+						<div style={emptyStateStyle} onClick={() => setShowNoteForm(true)}>
+							<div style={emptyStateIconStyle}>
+								<PlusIcon />
+							</div>
+							{t("applicationDetail.noNotes")}
+						</div>
+				)}
 				</div>
 			)}
 
@@ -451,7 +579,7 @@ export function ApplicationDetailPage() {
 	);
 }
 
-function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
+function NoteForm({ onSubmit, onClose }: { onSubmit: (text: string) => Promise<void>; onClose: () => void }) {
 	const { t } = useTranslation();
 	const [text, setText] = useState("");
 	const [submitting, setSubmitting] = useState(false);
@@ -469,7 +597,8 @@ function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
 	}
 
 	return (
-		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
+			<CloseButton onClick={onClose} />
 			<textarea
 				value={text}
 				onChange={(e) => setText(e.target.value)}
@@ -483,30 +612,12 @@ function NoteForm({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) {
 	);
 }
 
-function ToggleAddButton({ addLabel, open, onToggle }: { addLabel: string; open: boolean; onToggle: () => void }) {
-	const { t } = useTranslation();
-	return (
-		<button
-			onClick={onToggle}
-			style={{
-				border: open ? "1px solid var(--color-border)" : "none",
-				background: open ? "#fff" : "var(--color-accent)",
-				color: open ? "var(--color-text)" : "#fff",
-				borderRadius: 10,
-				padding: "9px 16px",
-				font: "600 13px var(--font-body)",
-				cursor: "pointer",
-			}}
-		>
-			{open ? t("applicationDetail.cancel") : addLabel}
-		</button>
-	);
-}
-
 function InterviewForm({
 	onSubmit,
+	onClose,
 }: {
 	onSubmit: (round: string, interviewer: string, scheduledAt: string, mode: string, notes: string) => Promise<void>;
+	onClose: () => void;
 }) {
 	const { t } = useTranslation();
 	const [round, setRound] = useState("");
@@ -533,7 +644,8 @@ function InterviewForm({
 	}
 
 	return (
-		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
+			<CloseButton onClick={onClose} />
 			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
 				<input
 					required
@@ -575,7 +687,13 @@ function InterviewForm({
 	);
 }
 
-function ContactForm({ onSubmit }: { onSubmit: (name: string, role: string, email: string) => Promise<void> }) {
+function ContactForm({
+	onSubmit,
+	onClose,
+}: {
+	onSubmit: (name: string, role: string, email: string) => Promise<void>;
+	onClose: () => void;
+}) {
 	const { t } = useTranslation();
 	const [name, setName] = useState("");
 	const [role, setRole] = useState("");
@@ -597,8 +715,9 @@ function ContactForm({ onSubmit }: { onSubmit: (name: string, role: string, emai
 	}
 
 	return (
-		<form onSubmit={handleSubmit} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 10 }}>
-			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
+			<CloseButton onClick={onClose} />
+			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
 				<input
 					required
 					placeholder={t("applicationDetail.contactForm.namePlaceholder")}

--- a/frontend/src/pages/ApplicationsPage.test.tsx
+++ b/frontend/src/pages/ApplicationsPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ApplicationsPage } from "./ApplicationsPage";
 import { AuthProvider } from "../context/AuthContext";
+import { ToastProvider } from "../context/ToastContext";
 import * as applicationsApi from "../api/applications";
 import type { Application, Page } from "../types/application";
 
@@ -31,13 +32,15 @@ function samplePage(content: Application[] = [SAMPLE_APPLICATION]): Page<Applica
 	return { content, totalElements: content.length, totalPages: 1, number: 0, size: 20 };
 }
 
-function renderApplicationsPage() {
+function renderApplicationsPage(initialEntries: Parameters<typeof MemoryRouter>[0]["initialEntries"] = ["/applications"]) {
 	localStorage.setItem("nextrole_email", "user@example.com");
 	localStorage.setItem("nextrole_token", "fake-token");
 	return render(
-		<MemoryRouter>
+		<MemoryRouter initialEntries={initialEntries}>
 			<AuthProvider>
-				<ApplicationsPage />
+				<ToastProvider>
+					<ApplicationsPage />
+				</ToastProvider>
 			</AuthProvider>
 		</MemoryRouter>
 	);
@@ -90,6 +93,16 @@ describe("ApplicationsPage", () => {
 
 		expect(await screen.findByText("Saved")).toBeInTheDocument();
 		expect(screen.queryByText("Company / Role")).not.toBeInTheDocument();
+	});
+
+	it("opens the create modal when clicking + New application", async () => {
+		vi.mocked(applicationsApi.listApplications).mockResolvedValue(samplePage());
+		renderApplicationsPage();
+
+		await screen.findByText("Acme Corp");
+		await userEvent.click(screen.getByText("+ New application"));
+
+		expect(await screen.findByRole("heading", { name: "New application" })).toBeInTheDocument();
 	});
 
 	it("deletes an application after confirmation", async () => {

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -14,6 +14,7 @@ import { StatusBadge } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
 import { IconButton, PencilIcon, TrashIcon } from "../components/IconButton";
 import { ApplicationBoard } from "../components/ApplicationBoard";
+import { useToast } from "../context/ToastContext";
 import { formatDate } from "../utils/date";
 import { formatSalaryRange } from "../utils/currency";
 import { formatLocation } from "../utils/workMode";
@@ -29,6 +30,7 @@ function isView(value: string | null): value is View {
 export function ApplicationsPage() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const { showToast } = useToast();
 	const [applications, setApplications] = useState<Application[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [search, setSearch] = useState("");
@@ -63,24 +65,46 @@ export function ApplicationsPage() {
 	}, [applications, search]);
 
 	async function handleCreate(request: CreateApplicationRequest) {
-		await createApplication(request);
-		await refresh();
+		try {
+			await createApplication(request);
+			showToast(t("applications.toasts.created"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	async function handleUpdate(id: string, request: CreateApplicationRequest) {
-		await updateApplication(id, request);
-		await refresh();
+		try {
+			await updateApplication(id, request);
+			showToast(t("applications.toasts.updated"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
 	}
 
 	async function handleDelete(id: string) {
 		if (!window.confirm(t("applications.confirmDelete"))) return;
-		await deleteApplication(id);
-		await refresh();
+		try {
+			await deleteApplication(id);
+			showToast(t("applications.toasts.deleted"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
+		}
 	}
 
 	async function handleBoardStatusChange(id: string, status: ApplicationStatus) {
-		await changeApplicationStatus(id, status);
-		await refresh();
+		try {
+			await changeApplicationStatus(id, status);
+			showToast(t("applications.toasts.statusChanged"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
+		}
 	}
 
 	function handleAddToStatus(status: ApplicationStatus) {
@@ -174,6 +198,10 @@ export function ApplicationsPage() {
 							textTransform: "uppercase",
 							letterSpacing: "0.03em",
 							borderBottom: "1px solid var(--color-border)",
+							position: "sticky",
+							top: 0,
+							background: "#fff",
+							zIndex: 1,
 						}}
 					>
 						<div>{t("applications.columns.companyRole")}</div>

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { DashboardPage } from "./DashboardPage";
 import { AuthProvider } from "../context/AuthContext";
+import { ToastProvider } from "../context/ToastContext";
 import * as dashboardApi from "../api/dashboard";
 import type { DashboardStatistics } from "../types/dashboard";
 
@@ -36,10 +37,12 @@ function renderDashboard() {
 	return render(
 		<MemoryRouter initialEntries={["/dashboard"]}>
 			<AuthProvider>
-				<Routes>
-					<Route path="/dashboard" element={<DashboardPage />} />
-					<Route path="/applications/:id" element={<div>Application detail</div>} />
-				</Routes>
+				<ToastProvider>
+					<Routes>
+						<Route path="/dashboard" element={<DashboardPage />} />
+						<Route path="/applications/:id" element={<div>Application detail</div>} />
+					</Routes>
+				</ToastProvider>
 			</AuthProvider>
 		</MemoryRouter>
 	);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { getDashboardStatistics } from "../api/dashboard";
+import { createApplication } from "../api/applications";
 import type { DashboardStatistics } from "../types/dashboard";
+import type { CreateApplicationRequest } from "../types/application";
 import { AppShell } from "../components/AppShell";
+import { ApplicationFormModal } from "../components/ApplicationFormModal";
 import { statusHue } from "../components/StatusBadge";
 import { formatDateTime } from "../utils/date";
+import { useToast } from "../context/ToastContext";
 
 const cardStyle: React.CSSProperties = {
 	background: "#fff",
@@ -17,11 +21,29 @@ const cardStyle: React.CSSProperties = {
 export function DashboardPage() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const { showToast } = useToast();
 	const [stats, setStats] = useState<DashboardStatistics | null>(null);
+	const [creating, setCreating] = useState(false);
+
+	async function refresh() {
+		const data = await getDashboardStatistics();
+		setStats(data);
+	}
 
 	useEffect(() => {
-		getDashboardStatistics().then(setStats);
+		refresh();
 	}, []);
+
+	async function handleCreate(request: CreateApplicationRequest) {
+		try {
+			await createApplication(request);
+			showToast(t("applications.toasts.created"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
+	}
 
 	if (!stats) {
 		return (
@@ -73,7 +95,7 @@ export function DashboardPage() {
 					</p>
 				</div>
 				<button
-					onClick={() => navigate("/applications")}
+					onClick={() => setCreating(true)}
 					style={{
 						border: "none",
 						borderRadius: 10,
@@ -180,6 +202,8 @@ export function DashboardPage() {
 				</div>
 				<div style={{ fontSize: 11.5, color: "var(--color-text-faint)", marginTop: 10 }}>{totalFunnelCount} total</div>
 			</div>
+
+			{creating && <ApplicationFormModal onSubmit={handleCreate} onClose={() => setCreating(false)} />}
 		</AppShell>
 	);
 }


### PR DESCRIPTION
Summary
  - Adds a toast notification system and wires it into every CRUD/status action across Dashboard, Applications, and Application detail.
  - Establishes a consistent close/add-icon visual language (shared CloseButton, PlusIcon reused everywhere) instead of ad hoc buttons.
  - Reworks the Application detail page's Interviews/Contacts/Notes tabs: centered empty states, inline add-tiles that open forms in place instead of jumping to the top of the page, and a Contact form
  sized like a contact card.
  - Redesigns Status History to match the north-star design (plain bold titles, no colored pill) and fixes the connector-line rendering.
  - Dashboard's "+ New application" now opens the modal in place instead of navigating away; Applications table headers stay visible on scroll.

<img width="1439" height="670" alt="Screenshot 2026-08-18 at 19 28 49" src="https://github.com/user-attachments/assets/8fa2ae5c-3145-4138-884d-9d00203db922" />
<img width="1439" height="670" alt="Screenshot 2026-08-18 at 19 28 57" src="https://github.com/user-attachments/assets/c0c308e4-800b-4dbb-af4a-5faab1988b01" />
<img width="1439" height="670" alt="Screenshot 2026-08-18 at 19 29 01" src="https://github.com/user-attachments/assets/583518f4-8506-42ac-a419-676800183f19" />
<img width="1439" height="670" alt="Screenshot 2026-08-18 at 19 37 01" src="https://github.com/user-attachments/assets/bb281726-793a-47fe-a604-86435fe56af2" />
