### PR TITLE
Edit + delete actions for interviews, contacts, notes, and applications

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/exception/ApiExceptions.kt
+++ b/backend/src/main/kotlin/com/nextrole/exception/ApiExceptions.kt
@@ -5,3 +5,5 @@ class EmailAlreadyRegisteredException(email: String) : RuntimeException("Email a
 class InvalidCredentialsException : RuntimeException("Invalid email or password")
 
 class ApplicationNotFoundException(id: Any) : RuntimeException("Application not found: $id")
+
+class ResourceNotFoundException(resource: String, id: Any) : RuntimeException("$resource not found: $id")

--- a/backend/src/main/kotlin/com/nextrole/exception/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/nextrole/exception/GlobalExceptionHandler.kt
@@ -23,6 +23,10 @@ class GlobalExceptionHandler {
 	fun handleApplicationNotFound(ex: ApplicationNotFoundException): ResponseEntity<ErrorResponse> =
 		ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(ex.message ?: "Not found"))
 
+	@ExceptionHandler(ResourceNotFoundException::class)
+	fun handleResourceNotFound(ex: ResourceNotFoundException): ResponseEntity<ErrorResponse> =
+		ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(ex.message ?: "Not found"))
+
 	@ExceptionHandler(MethodArgumentNotValidException::class)
 	fun handleValidation(ex: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
 		val message = ex.bindingResult.fieldErrors

--- a/backend/src/main/kotlin/com/nextrole/service/ContactService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/ContactService.kt
@@ -1,8 +1,10 @@
 package com.nextrole.service
 
 import com.nextrole.domain.Contact
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.ContactRepository
 import com.nextrole.web.dto.CreateContactRequest
+import com.nextrole.web.dto.UpdateContactRequest
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -26,5 +28,27 @@ class ContactService(
 	fun list(userId: UUID, applicationId: UUID): List<Contact> {
 		applicationService.get(userId, applicationId)
 		return contactRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
+	}
+
+	fun update(userId: UUID, applicationId: UUID, contactId: UUID, request: UpdateContactRequest): Contact {
+		val contact = get(userId, applicationId, contactId)
+		request.name?.let { contact.name = it }
+		request.role?.let { contact.role = it }
+		request.email?.let { contact.email = it }
+		return contactRepository.save(contact)
+	}
+
+	fun delete(userId: UUID, applicationId: UUID, contactId: UUID) {
+		val contact = get(userId, applicationId, contactId)
+		contactRepository.delete(contact)
+	}
+
+	private fun get(userId: UUID, applicationId: UUID, contactId: UUID): Contact {
+		applicationService.get(userId, applicationId)
+		val contact = contactRepository.findById(contactId).orElse(null)
+		if (contact == null || contact.applicationId != applicationId) {
+			throw ResourceNotFoundException("Contact", contactId)
+		}
+		return contact
 	}
 }

--- a/backend/src/main/kotlin/com/nextrole/service/InterviewService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/InterviewService.kt
@@ -1,8 +1,10 @@
 package com.nextrole.service
 
 import com.nextrole.domain.Interview
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.InterviewRepository
 import com.nextrole.web.dto.CreateInterviewRequest
+import com.nextrole.web.dto.UpdateInterviewRequest
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -28,5 +30,29 @@ class InterviewService(
 	fun list(userId: UUID, applicationId: UUID): List<Interview> {
 		applicationService.get(userId, applicationId)
 		return interviewRepository.findByApplicationIdOrderByScheduledAtAsc(applicationId)
+	}
+
+	fun update(userId: UUID, applicationId: UUID, interviewId: UUID, request: UpdateInterviewRequest): Interview {
+		val interview = get(userId, applicationId, interviewId)
+		request.round?.let { interview.round = it }
+		request.interviewer?.let { interview.interviewer = it }
+		request.scheduledAt?.let { interview.scheduledAt = it }
+		request.mode?.let { interview.mode = it }
+		request.notes?.let { interview.notes = it }
+		return interviewRepository.save(interview)
+	}
+
+	fun delete(userId: UUID, applicationId: UUID, interviewId: UUID) {
+		val interview = get(userId, applicationId, interviewId)
+		interviewRepository.delete(interview)
+	}
+
+	private fun get(userId: UUID, applicationId: UUID, interviewId: UUID): Interview {
+		applicationService.get(userId, applicationId)
+		val interview = interviewRepository.findById(interviewId).orElse(null)
+		if (interview == null || interview.applicationId != applicationId) {
+			throw ResourceNotFoundException("Interview", interviewId)
+		}
+		return interview
 	}
 }

--- a/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
@@ -1,8 +1,10 @@
 package com.nextrole.service
 
 import com.nextrole.domain.Note
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.NoteRepository
 import com.nextrole.web.dto.CreateNoteRequest
+import com.nextrole.web.dto.UpdateNoteRequest
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -21,5 +23,25 @@ class NoteService(
     fun list(userId: UUID, applicationId: UUID): List<Note> {
         applicationService.get(userId, applicationId)
         return noteRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
+    }
+
+    fun update(userId: UUID, applicationId: UUID, noteId: UUID, request: UpdateNoteRequest): Note {
+        val note = get(userId, applicationId, noteId)
+        request.text?.let { note.text = it }
+        return noteRepository.save(note)
+    }
+
+    fun delete(userId: UUID, applicationId: UUID, noteId: UUID) {
+        val note = get(userId, applicationId, noteId)
+        noteRepository.delete(note)
+    }
+
+    private fun get(userId: UUID, applicationId: UUID, noteId: UUID): Note {
+        applicationService.get(userId, applicationId)
+        val note = noteRepository.findById(noteId).orElse(null)
+        if (note == null || note.applicationId != applicationId) {
+            throw ResourceNotFoundException("Note", noteId)
+        }
+        return note
     }
 }

--- a/backend/src/main/kotlin/com/nextrole/web/ContactController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/ContactController.kt
@@ -4,11 +4,14 @@ import com.nextrole.security.CurrentUser
 import com.nextrole.service.ContactService
 import com.nextrole.web.dto.ContactResponse
 import com.nextrole.web.dto.CreateContactRequest
+import com.nextrole.web.dto.UpdateContactRequest
 import com.nextrole.web.dto.toResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -34,4 +37,18 @@ class ContactController(
 	@GetMapping
 	fun list(@PathVariable applicationId: UUID): List<ContactResponse> =
 		contactService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+
+	@PatchMapping("/{contactId}")
+	fun update(
+		@PathVariable applicationId: UUID,
+		@PathVariable contactId: UUID,
+		@RequestBody request: UpdateContactRequest
+	): ContactResponse =
+		contactService.update(CurrentUser.id(), applicationId, contactId, request).toResponse()
+
+	@DeleteMapping("/{contactId}")
+	fun delete(@PathVariable applicationId: UUID, @PathVariable contactId: UUID): ResponseEntity<Void> {
+		contactService.delete(CurrentUser.id(), applicationId, contactId)
+		return ResponseEntity.noContent().build()
+	}
 }

--- a/backend/src/main/kotlin/com/nextrole/web/InterviewController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/InterviewController.kt
@@ -4,11 +4,14 @@ import com.nextrole.security.CurrentUser
 import com.nextrole.service.InterviewService
 import com.nextrole.web.dto.CreateInterviewRequest
 import com.nextrole.web.dto.InterviewResponse
+import com.nextrole.web.dto.UpdateInterviewRequest
 import com.nextrole.web.dto.toResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -34,4 +37,18 @@ class InterviewController(
 	@GetMapping
 	fun list(@PathVariable applicationId: UUID): List<InterviewResponse> =
 		interviewService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+
+	@PatchMapping("/{interviewId}")
+	fun update(
+		@PathVariable applicationId: UUID,
+		@PathVariable interviewId: UUID,
+		@RequestBody request: UpdateInterviewRequest
+	): InterviewResponse =
+		interviewService.update(CurrentUser.id(), applicationId, interviewId, request).toResponse()
+
+	@DeleteMapping("/{interviewId}")
+	fun delete(@PathVariable applicationId: UUID, @PathVariable interviewId: UUID): ResponseEntity<Void> {
+		interviewService.delete(CurrentUser.id(), applicationId, interviewId)
+		return ResponseEntity.noContent().build()
+	}
 }

--- a/backend/src/main/kotlin/com/nextrole/web/NoteController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/NoteController.kt
@@ -4,11 +4,14 @@ import com.nextrole.security.CurrentUser
 import com.nextrole.service.NoteService
 import com.nextrole.web.dto.CreateNoteRequest
 import com.nextrole.web.dto.NoteResponse
+import com.nextrole.web.dto.UpdateNoteRequest
 import com.nextrole.web.dto.toResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -30,4 +33,18 @@ class NoteController(
     @GetMapping
     fun list(@PathVariable applicationId: UUID): List<NoteResponse> =
         noteService.list(CurrentUser.id(), applicationId).map { it.toResponse() }
+
+    @PatchMapping("/{noteId}")
+    fun update(
+        @PathVariable applicationId: UUID,
+        @PathVariable noteId: UUID,
+        @RequestBody request: UpdateNoteRequest
+    ): NoteResponse =
+        noteService.update(CurrentUser.id(), applicationId, noteId, request).toResponse()
+
+    @DeleteMapping("/{noteId}")
+    fun delete(@PathVariable applicationId: UUID, @PathVariable noteId: UUID): ResponseEntity<Void> {
+        noteService.delete(CurrentUser.id(), applicationId, noteId)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/backend/src/main/kotlin/com/nextrole/web/dto/ContactDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/ContactDtos.kt
@@ -11,6 +11,12 @@ data class CreateContactRequest(
 	val email: String? = null
 )
 
+data class UpdateContactRequest(
+	val name: String? = null,
+	val role: String? = null,
+	val email: String? = null
+)
+
 data class ContactResponse(
 	val id: UUID,
 	val name: String,

--- a/backend/src/main/kotlin/com/nextrole/web/dto/InterviewDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/InterviewDtos.kt
@@ -14,6 +14,14 @@ data class CreateInterviewRequest(
 	val notes: String? = null
 )
 
+data class UpdateInterviewRequest(
+	val round: String? = null,
+	val interviewer: String? = null,
+	val scheduledAt: Instant? = null,
+	val mode: String? = null,
+	val notes: String? = null
+)
+
 data class InterviewResponse(
 	val id: UUID,
 	val round: String,

--- a/backend/src/main/kotlin/com/nextrole/web/dto/NoteDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/NoteDtos.kt
@@ -9,6 +9,10 @@ data class CreateNoteRequest(
     @field:NotBlank val text: String
 )
 
+data class UpdateNoteRequest(
+    val text: String? = null
+)
+
 data class NoteResponse(
     val id: UUID,
     val text: String,

--- a/backend/src/test/kotlin/com/nextrole/service/ContactServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/ContactServiceTest.kt
@@ -3,8 +3,10 @@ package com.nextrole.service
 import com.nextrole.domain.Application
 import com.nextrole.domain.Contact
 import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.ContactRepository
 import com.nextrole.web.dto.CreateContactRequest
+import com.nextrole.web.dto.UpdateContactRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -12,6 +14,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.util.Optional
 import java.util.UUID
 
 class ContactServiceTest {
@@ -57,5 +60,44 @@ class ContactServiceTest {
 
 		assertEquals(1, result.size)
 		assertEquals("Lena Fischer", result[0].name)
+	}
+
+	@Test
+	fun `update changes only the provided fields`() {
+		val contactId = UUID.randomUUID()
+		val contact = Contact(id = contactId, applicationId = applicationId, name = "Lena Fischer")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { contactRepository.findById(contactId) } returns Optional.of(contact)
+		every { contactRepository.save(contact) } returns contact
+
+		val result = contactService.update(userId, applicationId, contactId, UpdateContactRequest(role = "Recruiter"))
+
+		assertEquals("Recruiter", result.role)
+		assertEquals("Lena Fischer", result.name)
+	}
+
+	@Test
+	fun `update throws when the contact belongs to a different application`() {
+		val contactId = UUID.randomUUID()
+		val contact = Contact(id = contactId, applicationId = UUID.randomUUID(), name = "Lena Fischer")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { contactRepository.findById(contactId) } returns Optional.of(contact)
+
+		assertThrows(ResourceNotFoundException::class.java) {
+			contactService.update(userId, applicationId, contactId, UpdateContactRequest(role = "Recruiter"))
+		}
+	}
+
+	@Test
+	fun `delete removes an owned contact`() {
+		val contactId = UUID.randomUUID()
+		val contact = Contact(id = contactId, applicationId = applicationId, name = "Lena Fischer")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { contactRepository.findById(contactId) } returns Optional.of(contact)
+		every { contactRepository.delete(contact) } returns Unit
+
+		contactService.delete(userId, applicationId, contactId)
+
+		verify(exactly = 1) { contactRepository.delete(contact) }
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/service/InterviewServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/InterviewServiceTest.kt
@@ -3,8 +3,10 @@ package com.nextrole.service
 import com.nextrole.domain.Application
 import com.nextrole.domain.Interview
 import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.InterviewRepository
 import com.nextrole.web.dto.CreateInterviewRequest
+import com.nextrole.web.dto.UpdateInterviewRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.Optional
 import java.util.UUID
 
 class InterviewServiceTest {
@@ -63,5 +66,43 @@ class InterviewServiceTest {
 
 		assertEquals(1, result.size)
 		assertEquals("HR Screen", result[0].round)
+	}
+
+	@Test
+	fun `update changes only the provided fields`() {
+		val interviewId = UUID.randomUUID()
+		val interview = Interview(id = interviewId, applicationId = applicationId, round = "HR Screen", scheduledAt = Instant.now())
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { interviewRepository.findById(interviewId) } returns Optional.of(interview)
+		every { interviewRepository.save(interview) } returns interview
+
+		val result = interviewService.update(userId, applicationId, interviewId, UpdateInterviewRequest(round = "Technical Interview"))
+
+		assertEquals("Technical Interview", result.round)
+	}
+
+	@Test
+	fun `update throws when the interview belongs to a different application`() {
+		val interviewId = UUID.randomUUID()
+		val interview = Interview(id = interviewId, applicationId = UUID.randomUUID(), round = "HR Screen", scheduledAt = Instant.now())
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { interviewRepository.findById(interviewId) } returns Optional.of(interview)
+
+		assertThrows(ResourceNotFoundException::class.java) {
+			interviewService.update(userId, applicationId, interviewId, UpdateInterviewRequest(round = "Technical Interview"))
+		}
+	}
+
+	@Test
+	fun `delete removes an owned interview`() {
+		val interviewId = UUID.randomUUID()
+		val interview = Interview(id = interviewId, applicationId = applicationId, round = "HR Screen", scheduledAt = Instant.now())
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { interviewRepository.findById(interviewId) } returns Optional.of(interview)
+		every { interviewRepository.delete(interview) } returns Unit
+
+		interviewService.delete(userId, applicationId, interviewId)
+
+		verify(exactly = 1) { interviewRepository.delete(interview) }
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
@@ -3,8 +3,10 @@ package com.nextrole.service
 import com.nextrole.domain.Application
 import com.nextrole.domain.Note
 import com.nextrole.exception.ApplicationNotFoundException
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.repository.NoteRepository
 import com.nextrole.web.dto.CreateNoteRequest
+import com.nextrole.web.dto.UpdateNoteRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -12,6 +14,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.util.Optional
 import java.util.UUID
 
 class NoteServiceTest {
@@ -63,5 +66,43 @@ class NoteServiceTest {
 		assertThrows(ApplicationNotFoundException::class.java) {
 			noteService.list(userId, applicationId)
 		}
+	}
+
+	@Test
+	fun `update changes the note text`() {
+		val noteId = UUID.randomUUID()
+		val note = Note(id = noteId, applicationId = applicationId, text = "First note")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { noteRepository.findById(noteId) } returns Optional.of(note)
+		every { noteRepository.save(note) } returns note
+
+		val result = noteService.update(userId, applicationId, noteId, UpdateNoteRequest("Updated note"))
+
+		assertEquals("Updated note", result.text)
+	}
+
+	@Test
+	fun `update throws when the note belongs to a different application`() {
+		val noteId = UUID.randomUUID()
+		val note = Note(id = noteId, applicationId = UUID.randomUUID(), text = "First note")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { noteRepository.findById(noteId) } returns Optional.of(note)
+
+		assertThrows(ResourceNotFoundException::class.java) {
+			noteService.update(userId, applicationId, noteId, UpdateNoteRequest("Updated note"))
+		}
+	}
+
+	@Test
+	fun `delete removes an owned note`() {
+		val noteId = UUID.randomUUID()
+		val note = Note(id = noteId, applicationId = applicationId, text = "First note")
+		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
+		every { noteRepository.findById(noteId) } returns Optional.of(note)
+		every { noteRepository.delete(note) } returns Unit
+
+		noteService.delete(userId, applicationId, noteId)
+
+		verify(exactly = 1) { noteRepository.delete(note) }
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/web/ContactControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/ContactControllerTest.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.nextrole.domain.Contact
 import com.nextrole.service.ContactService
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.web.dto.CreateContactRequest
+import com.nextrole.web.dto.UpdateContactRequest
 import io.mockk.every
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +18,9 @@ import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.util.UUID
 
@@ -80,6 +84,46 @@ class ContactControllerTest {
 		mockMvc.get("/api/applications/$applicationId/contacts").andExpect {
 			status { isOk() }
 			jsonPath("$[0].name") { value("Lena Fischer") }
+		}
+	}
+
+	@Test
+	fun `update returns 200 with the updated contact`() {
+		val contactId = UUID.randomUUID()
+		val request = UpdateContactRequest(role = "Recruiter")
+		val updated = Contact(applicationId = applicationId, name = "Lena Fischer", role = "Recruiter")
+		every { contactService.update(userId, applicationId, contactId, request) } returns updated
+
+		mockMvc.patch("/api/applications/$applicationId/contacts/$contactId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isOk() }
+			jsonPath("$.role") { value("Recruiter") }
+		}
+	}
+
+	@Test
+	fun `update returns 404 when the contact is not found`() {
+		val contactId = UUID.randomUUID()
+		val request = UpdateContactRequest(role = "Recruiter")
+		every { contactService.update(userId, applicationId, contactId, request) } throws ResourceNotFoundException("Contact", contactId)
+
+		mockMvc.patch("/api/applications/$applicationId/contacts/$contactId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isNotFound() }
+		}
+	}
+
+	@Test
+	fun `delete returns 204`() {
+		val contactId = UUID.randomUUID()
+		every { contactService.delete(userId, applicationId, contactId) } returns Unit
+
+		mockMvc.delete("/api/applications/$applicationId/contacts/$contactId").andExpect {
+			status { isNoContent() }
 		}
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/web/InterviewControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/InterviewControllerTest.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.nextrole.domain.Interview
 import com.nextrole.service.InterviewService
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.web.dto.CreateInterviewRequest
+import com.nextrole.web.dto.UpdateInterviewRequest
 import io.mockk.every
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +18,9 @@ import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.Instant
 import java.util.UUID
@@ -82,6 +86,46 @@ class InterviewControllerTest {
 		mockMvc.get("/api/applications/$applicationId/interviews").andExpect {
 			status { isOk() }
 			jsonPath("$[0].round") { value("HR Screen") }
+		}
+	}
+
+	@Test
+	fun `update returns 200 with the updated interview`() {
+		val interviewId = UUID.randomUUID()
+		val request = UpdateInterviewRequest(round = "Technical Interview")
+		val updated = Interview(applicationId = applicationId, round = "Technical Interview", scheduledAt = Instant.now())
+		every { interviewService.update(userId, applicationId, interviewId, request) } returns updated
+
+		mockMvc.patch("/api/applications/$applicationId/interviews/$interviewId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isOk() }
+			jsonPath("$.round") { value("Technical Interview") }
+		}
+	}
+
+	@Test
+	fun `update returns 404 when the interview is not found`() {
+		val interviewId = UUID.randomUUID()
+		val request = UpdateInterviewRequest(round = "Technical Interview")
+		every { interviewService.update(userId, applicationId, interviewId, request) } throws ResourceNotFoundException("Interview", interviewId)
+
+		mockMvc.patch("/api/applications/$applicationId/interviews/$interviewId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isNotFound() }
+		}
+	}
+
+	@Test
+	fun `delete returns 204`() {
+		val interviewId = UUID.randomUUID()
+		every { interviewService.delete(userId, applicationId, interviewId) } returns Unit
+
+		mockMvc.delete("/api/applications/$applicationId/interviews/$interviewId").andExpect {
+			status { isNoContent() }
 		}
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/web/NoteControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/NoteControllerTest.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.nextrole.domain.Note
 import com.nextrole.service.NoteService
+import com.nextrole.exception.ResourceNotFoundException
 import com.nextrole.web.dto.CreateNoteRequest
+import com.nextrole.web.dto.UpdateNoteRequest
 import io.mockk.every
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +18,9 @@ import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.util.UUID
 
@@ -80,6 +84,46 @@ class NoteControllerTest {
 		mockMvc.get("/api/applications/$applicationId/notes").andExpect {
 			status { isOk() }
 			jsonPath("$[0].text") { value("First note") }
+		}
+	}
+
+	@Test
+	fun `update returns 200 with the updated note`() {
+		val noteId = UUID.randomUUID()
+		val request = UpdateNoteRequest("Updated note")
+		val updated = Note(applicationId = applicationId, text = "Updated note")
+		every { noteService.update(userId, applicationId, noteId, request) } returns updated
+
+		mockMvc.patch("/api/applications/$applicationId/notes/$noteId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isOk() }
+			jsonPath("$.text") { value("Updated note") }
+		}
+	}
+
+	@Test
+	fun `update returns 404 when the note is not found`() {
+		val noteId = UUID.randomUUID()
+		val request = UpdateNoteRequest("Updated note")
+		every { noteService.update(userId, applicationId, noteId, request) } throws ResourceNotFoundException("Note", noteId)
+
+		mockMvc.patch("/api/applications/$applicationId/notes/$noteId") {
+			contentType = MediaType.APPLICATION_JSON
+			content = objectMapper.writeValueAsString(request)
+		}.andExpect {
+			status { isNotFound() }
+		}
+	}
+
+	@Test
+	fun `delete returns 204`() {
+		val noteId = UUID.randomUUID()
+		every { noteService.delete(userId, applicationId, noteId) } returns Unit
+
+		mockMvc.delete("/api/applications/$applicationId/notes/$noteId").andExpect {
+			status { isNoContent() }
 		}
 	}
 }

--- a/frontend/src/api/applications.ts
+++ b/frontend/src/api/applications.ts
@@ -12,6 +12,9 @@ import type {
 	Page,
 	StatusHistoryEntry,
 	UpdateApplicationRequest,
+	UpdateContactRequest,
+	UpdateInterviewRequest,
+	UpdateNoteRequest,
 } from "../types/application";
 
 export async function listApplications(): Promise<Page<Application>> {
@@ -44,6 +47,15 @@ export async function createNote(applicationId: string, request: CreateNoteReque
 	return response.data;
 }
 
+export async function updateNote(applicationId: string, noteId: string, request: UpdateNoteRequest): Promise<Note> {
+	const response = await apiClient.patch<Note>(`/api/applications/${applicationId}/notes/${noteId}`, request);
+	return response.data;
+}
+
+export async function deleteNote(applicationId: string, noteId: string): Promise<void> {
+	await apiClient.delete(`/api/applications/${applicationId}/notes/${noteId}`);
+}
+
 export async function listInterviews(applicationId: string): Promise<Interview[]> {
 	const response = await apiClient.get<Interview[]>(`/api/applications/${applicationId}/interviews`);
 	return response.data;
@@ -54,6 +66,22 @@ export async function createInterview(applicationId: string, request: CreateInte
 	return response.data;
 }
 
+export async function updateInterview(
+	applicationId: string,
+	interviewId: string,
+	request: UpdateInterviewRequest
+): Promise<Interview> {
+	const response = await apiClient.patch<Interview>(
+		`/api/applications/${applicationId}/interviews/${interviewId}`,
+		request
+	);
+	return response.data;
+}
+
+export async function deleteInterview(applicationId: string, interviewId: string): Promise<void> {
+	await apiClient.delete(`/api/applications/${applicationId}/interviews/${interviewId}`);
+}
+
 export async function listContacts(applicationId: string): Promise<Contact[]> {
 	const response = await apiClient.get<Contact[]>(`/api/applications/${applicationId}/contacts`);
 	return response.data;
@@ -62,6 +90,22 @@ export async function listContacts(applicationId: string): Promise<Contact[]> {
 export async function createContact(applicationId: string, request: CreateContactRequest): Promise<Contact> {
 	const response = await apiClient.post<Contact>(`/api/applications/${applicationId}/contacts`, request);
 	return response.data;
+}
+
+export async function updateContact(
+	applicationId: string,
+	contactId: string,
+	request: UpdateContactRequest
+): Promise<Contact> {
+	const response = await apiClient.patch<Contact>(
+		`/api/applications/${applicationId}/contacts/${contactId}`,
+		request
+	);
+	return response.data;
+}
+
+export async function deleteContact(applicationId: string, contactId: string): Promise<void> {
+	await apiClient.delete(`/api/applications/${applicationId}/contacts/${contactId}`);
 }
 
 export async function createApplication(request: CreateApplicationRequest): Promise<Application> {

--- a/frontend/src/components/ApplicationBoard.test.tsx
+++ b/frontend/src/components/ApplicationBoard.test.tsx
@@ -34,19 +34,33 @@ const APP_APPLIED: Application = {
 	updatedAt: "2026-08-01T00:00:00Z",
 };
 
-function renderBoard(applications: Application[], onStatusChange = vi.fn(), onAddToStatus = vi.fn()) {
+function renderBoard(
+	applications: Application[],
+	onStatusChange = vi.fn(),
+	onAddToStatus = vi.fn(),
+	onEdit = vi.fn(),
+	onDelete = vi.fn()
+) {
 	render(
 		<MemoryRouter initialEntries={["/applications"]}>
 			<Routes>
 				<Route
 					path="/applications"
-					element={<ApplicationBoard applications={applications} onStatusChange={onStatusChange} onAddToStatus={onAddToStatus} />}
+					element={
+						<ApplicationBoard
+							applications={applications}
+							onStatusChange={onStatusChange}
+							onAddToStatus={onAddToStatus}
+							onEdit={onEdit}
+							onDelete={onDelete}
+						/>
+					}
 				/>
 				<Route path="/applications/:id" element={<div>Application detail</div>} />
 			</Routes>
 		</MemoryRouter>
 	);
-	return { onStatusChange, onAddToStatus };
+	return { onStatusChange, onAddToStatus, onEdit, onDelete };
 }
 
 describe("ApplicationBoard", () => {
@@ -86,7 +100,19 @@ describe("ApplicationBoard", () => {
 		expect(onAddToStatus).toHaveBeenCalledWith("SAVED");
 
 		const appliedColumn = screen.getByTestId("board-column-APPLIED");
-		expect(appliedColumn.querySelectorAll("button")).toHaveLength(1);
+		expect(appliedColumn.querySelectorAll("button")).toHaveLength(2);
+	});
+
+	it("opens the kebab menu and triggers edit/delete", async () => {
+		const { onEdit, onDelete } = renderBoard([APP_APPLIED]);
+
+		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+		expect(onEdit).toHaveBeenCalledWith(APP_APPLIED);
+
+		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		expect(onDelete).toHaveBeenCalledWith("app-1");
 	});
 
 	it("calls onStatusChange with the target column when a card is dropped", () => {

--- a/frontend/src/components/ApplicationBoard.tsx
+++ b/frontend/src/components/ApplicationBoard.tsx
@@ -1,10 +1,12 @@
 import { useState, type DragEvent } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import type { Application, ApplicationStatus } from "../types/application";
 import { statusHue, statusOptions } from "./StatusBadge";
 import { formatSalaryRange } from "../utils/currency";
 import { formatLocation } from "../utils/workMode";
 import { PlusIcon } from "./IconButton";
+import { KebabMenu } from "./KebabMenu";
 
 const cardStyle: React.CSSProperties = {
 	background: "#fff",
@@ -21,10 +23,13 @@ interface Props {
 	applications: Application[];
 	onStatusChange: (applicationId: string, status: ApplicationStatus) => void;
 	onAddToStatus: (status: ApplicationStatus) => void;
+	onEdit: (application: Application) => void;
+	onDelete: (applicationId: string) => void;
 }
 
-export function ApplicationBoard({ applications, onStatusChange, onAddToStatus }: Props) {
+export function ApplicationBoard({ applications, onStatusChange, onAddToStatus, onEdit, onDelete }: Props) {
 	const navigate = useNavigate();
+	const { t } = useTranslation();
 	const [dragOverStatus, setDragOverStatus] = useState<ApplicationStatus | null>(null);
 
 	const columns = statusOptions().map((opt) => ({
@@ -114,9 +119,18 @@ export function ApplicationBoard({ applications, onStatusChange, onAddToStatus }
 								onClick={() => navigate(`/applications/${app.id}`)}
 								style={cardStyle}
 							>
-								<div>
-									<div style={{ fontWeight: 600, fontSize: 13.5 }}>{app.company}</div>
-									<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>{app.role}</div>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 6 }}>
+									<div style={{ minWidth: 0 }}>
+										<div style={{ fontWeight: 600, fontSize: 13.5 }}>{app.company}</div>
+										<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>{app.role}</div>
+									</div>
+									<KebabMenu
+										ariaLabel={t("applications.actionsAria", { company: app.company })}
+										items={[
+											{ label: t("common.edit"), onClick: () => onEdit(app) },
+											{ label: t("common.delete"), onClick: () => onDelete(app.id), variant: "danger" },
+										]}
+									/>
 								</div>
 								<div style={{ fontSize: 11.5, color: "var(--color-text-faint)" }}>
 									{[formatLocation(app.location, app.workMode), formatSalaryRange(app.salaryMin, app.salaryMax, app.currency)]

--- a/frontend/src/components/ApplicationFormModal.tsx
+++ b/frontend/src/components/ApplicationFormModal.tsx
@@ -48,9 +48,10 @@ interface Props {
 	initialStatus?: ApplicationStatus;
 	onSubmit: (request: CreateApplicationRequest) => Promise<void>;
 	onClose: () => void;
+	onDelete?: () => void;
 }
 
-export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose }: Props) {
+export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose, onDelete }: Props) {
 	const { t } = useTranslation();
 	const [form, setForm] = useState<CreateApplicationRequest>({
 		company: initial?.company ?? "",
@@ -214,7 +215,24 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 							style={{ ...inputStyle, minHeight: 70, resize: "vertical" }}
 						/>
 					</label>
-					<div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 6 }}>
+					<div style={{ display: "flex", gap: 10, justifyContent: onDelete ? "space-between" : "flex-end", marginTop: 6 }}>
+						{onDelete && (
+							<button
+								type="button"
+								onClick={onDelete}
+								style={{
+									border: "1px solid oklch(50% 0.15 30)",
+									borderRadius: 10,
+									padding: "10px 16px",
+									background: "#fff",
+									color: "oklch(50% 0.15 30)",
+									font: "600 13px var(--font-body)",
+									cursor: "pointer",
+								}}
+							>
+								{t("applicationForm.deleteCta")}
+							</button>
+						)}
 						<button
 							type="submit"
 							disabled={submitting}

--- a/frontend/src/components/IconButton.tsx
+++ b/frontend/src/components/IconButton.tsx
@@ -56,6 +56,16 @@ export function XIcon() {
 	);
 }
 
+export function DotsIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+			<circle cx="5" cy="12" r="2" />
+			<circle cx="12" cy="12" r="2" />
+			<circle cx="19" cy="12" r="2" />
+		</svg>
+	);
+}
+
 export function TrashIcon() {
 	return (
 		<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/components/KebabMenu.tsx
+++ b/frontend/src/components/KebabMenu.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import { DotsIcon } from "./IconButton";
+
+interface MenuItem {
+	label: string;
+	onClick: () => void;
+	variant?: "default" | "danger";
+}
+
+interface Props {
+	items: MenuItem[];
+	ariaLabel: string;
+}
+
+export function KebabMenu({ items, ariaLabel }: Props) {
+	const [open, setOpen] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		function handleOutsideClick(e: MouseEvent) {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		}
+		function handleEscape(e: KeyboardEvent) {
+			if (e.key === "Escape") setOpen(false);
+		}
+		document.addEventListener("mousedown", handleOutsideClick);
+		document.addEventListener("keydown", handleEscape);
+		return () => {
+			document.removeEventListener("mousedown", handleOutsideClick);
+			document.removeEventListener("keydown", handleEscape);
+		};
+	}, [open]);
+
+	return (
+		<div ref={containerRef} style={{ position: "relative" }}>
+			<button
+				type="button"
+				onClick={(e) => {
+					e.stopPropagation();
+					setOpen((v) => !v);
+				}}
+				aria-label={ariaLabel}
+				aria-haspopup="menu"
+				aria-expanded={open}
+				title={ariaLabel}
+				style={{
+					display: "inline-flex",
+					alignItems: "center",
+					justifyContent: "center",
+					width: 30,
+					height: 30,
+					border: "none",
+					borderRadius: 8,
+					background: "transparent",
+					color: "var(--color-text-muted)",
+					cursor: "pointer",
+				}}
+			>
+				<DotsIcon />
+			</button>
+			{open && (
+				<div
+					role="menu"
+					onClick={(e) => e.stopPropagation()}
+					style={{
+						position: "absolute",
+						top: "calc(100% + 4px)",
+						right: 0,
+						background: "#fff",
+						border: "1px solid var(--color-border)",
+						borderRadius: 12,
+						boxShadow: "0 12px 32px oklch(22% 0.014 250 / 0.12)",
+						padding: 6,
+						display: "flex",
+						flexDirection: "column",
+						gap: 2,
+						zIndex: 5,
+						minWidth: 140,
+					}}
+				>
+					{items.map((item) => (
+						<button
+							key={item.label}
+							type="button"
+							role="menuitem"
+							onClick={() => {
+								setOpen(false);
+								item.onClick();
+							}}
+							style={{
+								border: "none",
+								background: "transparent",
+								borderRadius: 8,
+								padding: "8px 10px",
+								font: "500 13px var(--font-body)",
+								textAlign: "left",
+								cursor: "pointer",
+								color: item.variant === "danger" ? "oklch(50% 0.15 30)" : "var(--color-text)",
+							}}
+						>
+							{item.label}
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2,6 +2,11 @@
 	"app": {
 		"name": "NextRole"
 	},
+	"common": {
+		"actions": "Actions",
+		"edit": "Edit",
+		"delete": "Delete"
+	},
 	"nav": {
 		"logOut": "Log out",
 		"collapseSidebar": "Collapse sidebar",
@@ -81,8 +86,7 @@
 		"loading": "Loading…",
 		"empty": "No applications yet. Add your first one.",
 		"confirmDelete": "Delete this application?",
-		"editAria": "Edit {{company}}",
-		"deleteAria": "Delete {{company}}",
+		"actionsAria": "Actions for {{company}}",
 		"toasts": {
 			"created": "Application created",
 			"updated": "Application updated",
@@ -121,7 +125,8 @@
 		"notes": "Notes",
 		"cancel": "Cancel",
 		"createCta": "Create application",
-		"saveCta": "Save changes"
+		"saveCta": "Save changes",
+		"deleteCta": "Delete application"
 	},
 	"applicationDetail": {
 		"back": "← Back to applications",
@@ -148,27 +153,42 @@
 		"addContact": "Add contact",
 		"addNote": "Add note",
 		"cancel": "Cancel",
+		"noteActionsAria": "Note actions",
+		"interviewActionsAria": "Actions for {{round}}",
+		"contactActionsAria": "Actions for {{name}}",
+		"confirmDeleteNote": "Delete this note?",
+		"confirmDeleteInterview": "Delete this interview?",
+		"confirmDeleteContact": "Delete this contact?",
 		"toasts": {
 			"noteAdded": "Note added",
+			"noteUpdated": "Note updated",
+			"noteDeleted": "Note deleted",
 			"interviewAdded": "Interview added",
-			"contactAdded": "Contact added"
+			"interviewUpdated": "Interview updated",
+			"interviewDeleted": "Interview deleted",
+			"contactAdded": "Contact added",
+			"contactUpdated": "Contact updated",
+			"contactDeleted": "Contact deleted"
 		},
 		"noteForm": {
 			"placeholder": "Add a note…",
-			"submit": "Add note"
+			"submit": "Add note",
+			"saveCta": "Save changes"
 		},
 		"interviewForm": {
 			"roundPlaceholder": "Round (e.g. HR Screen)",
 			"interviewerPlaceholder": "Interviewer",
 			"modePlaceholder": "Mode (e.g. Video call)",
 			"notesPlaceholder": "Notes (optional)",
-			"submit": "Add interview"
+			"submit": "Add interview",
+			"saveCta": "Save changes"
 		},
 		"contactForm": {
 			"namePlaceholder": "Name",
 			"rolePlaceholder": "Role",
 			"emailPlaceholder": "Email",
-			"submit": "Add contact"
+			"submit": "Add contact",
+			"saveCta": "Save changes"
 		}
 	}
 }

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -158,4 +158,93 @@ describe("ApplicationDetailPage", () => {
 
 		expect(screen.getByText("HR Screen")).toBeInTheDocument();
 	});
+
+	it("edits an existing note", async () => {
+		const existingNote: Note = { id: "n1", text: "First call went well.", createdAt: "2026-08-01T00:00:00Z" };
+		vi.mocked(applicationsApi.listNotes).mockResolvedValue([existingNote]);
+		vi.mocked(applicationsApi.updateNote).mockResolvedValue({ ...existingNote, text: "Updated note" });
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Notes"));
+		await userEvent.click(screen.getByLabelText("Note actions"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+
+		const textarea = screen.getByPlaceholderText("Add a note…");
+		expect(textarea).toHaveValue("First call went well.");
+		await userEvent.clear(textarea);
+		await userEvent.type(textarea, "Updated note");
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => {
+			expect(applicationsApi.updateNote).toHaveBeenCalledWith("app-1", "n1", { text: "Updated note" });
+		});
+	});
+
+	it("deletes a note after confirmation", async () => {
+		const existingNote: Note = { id: "n1", text: "First call went well.", createdAt: "2026-08-01T00:00:00Z" };
+		vi.mocked(applicationsApi.listNotes).mockResolvedValue([existingNote]);
+		vi.mocked(applicationsApi.deleteNote).mockResolvedValue(undefined);
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Notes"));
+		await userEvent.click(screen.getByLabelText("Note actions"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+		await waitFor(() => {
+			expect(applicationsApi.deleteNote).toHaveBeenCalledWith("app-1", "n1");
+		});
+	});
+
+	it("edits an existing contact", async () => {
+		const existingContact: Contact = { id: "c1", name: "Lena Fischer", role: "Talent Partner", email: null, createdAt: "2026-08-01T00:00:00Z" };
+		vi.mocked(applicationsApi.listContacts).mockResolvedValue([existingContact]);
+		vi.mocked(applicationsApi.updateContact).mockResolvedValue({ ...existingContact, role: "Recruiter" });
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Contacts"));
+		await userEvent.click(screen.getByLabelText("Actions for Lena Fischer"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+
+		const roleInput = screen.getByPlaceholderText("Role");
+		await userEvent.clear(roleInput);
+		await userEvent.type(roleInput, "Recruiter");
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => {
+			expect(applicationsApi.updateContact).toHaveBeenCalledWith("app-1", "c1", {
+				name: "Lena Fischer",
+				role: "Recruiter",
+				email: undefined,
+			});
+		});
+	});
+
+	it("deletes an interview after confirmation", async () => {
+		const existingInterview: Interview = {
+			id: "iv1",
+			round: "HR Screen",
+			interviewer: "Lena Fischer",
+			scheduledAt: "2026-08-05T10:00:00Z",
+			mode: "Video call",
+			notes: null,
+			createdAt: "2026-08-01T00:00:00Z",
+		};
+		vi.mocked(applicationsApi.listInterviews).mockResolvedValue([existingInterview]);
+		vi.mocked(applicationsApi.deleteInterview).mockResolvedValue(undefined);
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Interviews"));
+		await userEvent.click(screen.getByLabelText("Actions for HR Screen"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+		await waitFor(() => {
+			expect(applicationsApi.deleteInterview).toHaveBeenCalledWith("app-1", "iv1");
+		});
+	});
 });

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -562,34 +562,32 @@ export function ApplicationDetailPage() {
 								onClose={() => setEditingInterviewId(null)}
 							/>
 						) : (
-							<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 6 }}>
+							<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 2 }}>
 								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
 									<span style={{ fontWeight: 700, fontSize: 14 }}>{iv.round}</span>
-									<div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-										<span style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
-											{formatDateTime(iv.scheduledAt)}
-										</span>
-										<KebabMenu
-											ariaLabel={t("applicationDetail.interviewActionsAria", { round: iv.round })}
-											items={[
-												{
-													label: t("common.edit"),
-													onClick: () => {
-														setShowInterviewForm(false);
-														setEditingInterviewId(iv.id);
-													},
+									<KebabMenu
+										ariaLabel={t("applicationDetail.interviewActionsAria", { round: iv.round })}
+										items={[
+											{
+												label: t("common.edit"),
+												onClick: () => {
+													setShowInterviewForm(false);
+													setEditingInterviewId(iv.id);
 												},
-												{ label: t("common.delete"), onClick: () => handleDeleteInterview(iv.id), variant: "danger" },
-											]}
-										/>
-									</div>
+											},
+											{ label: t("common.delete"), onClick: () => handleDeleteInterview(iv.id), variant: "danger" },
+										]}
+									/>
 								</div>
-								{(iv.interviewer || iv.mode) && (
-									<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+									<div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
 										{[iv.interviewer, iv.mode].filter(Boolean).join(" · ")}
 									</div>
-								)}
-								{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
+									<span style={{ fontSize: 12, color: "var(--color-text-faint)" }}>
+										{formatDateTime(iv.scheduledAt)}
+									</span>
+								</div>
+								{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)" }}>{iv.notes}</div>}
 							</div>
 						)
 					)}
@@ -654,7 +652,7 @@ export function ApplicationDetailPage() {
 										{c.name.charAt(0).toUpperCase()}
 									</div>
 									<div style={{ minWidth: 0, flex: 1 }}>
-										<div style={{ fontWeight: 600, fontSize: 13.5 }}>{c.name}</div>
+										<div style={{ fontWeight: 700, fontSize: 14 }}>{c.name}</div>
 										{c.role && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.role}</div>}
 										{c.email && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.email}</div>}
 									</div>
@@ -720,8 +718,8 @@ export function ApplicationDetailPage() {
 							/>
 						) : (
 							<div key={n.id} style={{ ...cardStyle, padding: "16px 18px" }}>
-								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-									<div style={{ fontSize: 11.5, color: "var(--color-text-faint)" }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 2 }}>
+									<div style={{ fontSize: 12, color: "var(--color-text-faint)" }}>
 										{formatDateTime(n.createdAt)}
 									</div>
 									<KebabMenu
@@ -863,7 +861,7 @@ function InterviewForm({
 	return (
 		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
 			<CloseButton onClick={onClose} />
-			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10 }}>
 				<input
 					required
 					placeholder={t("applicationDetail.interviewForm.roundPlaceholder")}

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -6,12 +6,19 @@ import {
 	createContact,
 	createInterview,
 	createNote,
+	deleteApplication,
+	deleteContact,
+	deleteInterview,
+	deleteNote,
 	getApplication,
 	getApplicationHistory,
 	listContacts,
 	listInterviews,
 	listNotes,
 	updateApplication,
+	updateContact,
+	updateInterview,
+	updateNote,
 } from "../api/applications";
 import type {
 	Application,
@@ -27,6 +34,7 @@ import { StatusBadge, statusOptions } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
 import { CloseButton } from "../components/CloseButton";
 import { PlusIcon } from "../components/IconButton";
+import { KebabMenu } from "../components/KebabMenu";
 import { useToast } from "../context/ToastContext";
 import { formatDate, formatDateTime } from "../utils/date";
 import { formatSalaryRange } from "../utils/currency";
@@ -108,6 +116,12 @@ const addButtonStyle: React.CSSProperties = {
 	alignSelf: "flex-end",
 };
 
+function toDateTimeLocal(iso: string): string {
+	const d = new Date(iso);
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export function ApplicationDetailPage() {
 	const { t } = useTranslation();
 	const { id } = useParams<{ id: string }>();
@@ -124,6 +138,9 @@ export function ApplicationDetailPage() {
 	const [showNoteForm, setShowNoteForm] = useState(false);
 	const [showInterviewForm, setShowInterviewForm] = useState(false);
 	const [showContactForm, setShowContactForm] = useState(false);
+	const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
+	const [editingInterviewId, setEditingInterviewId] = useState<string | null>(null);
+	const [editingContactId, setEditingContactId] = useState<string | null>(null);
 
 	async function refresh() {
 		if (!id) return;
@@ -155,6 +172,18 @@ export function ApplicationDetailPage() {
 		} catch (error) {
 			showToast(t("applications.toasts.error"), "error");
 			throw error;
+		}
+	}
+
+	async function handleDeleteApplication() {
+		if (!id) return;
+		if (!window.confirm(t("applications.confirmDelete"))) return;
+		try {
+			await deleteApplication(id);
+			showToast(t("applications.toasts.deleted"), "success");
+			navigate("/applications");
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
 		}
 	}
 
@@ -212,6 +241,94 @@ export function ApplicationDetailPage() {
 		} catch (error) {
 			showToast(t("applications.toasts.error"), "error");
 			throw error;
+		}
+	}
+
+	async function handleUpdateNote(noteId: string, text: string) {
+		if (!id) return;
+		try {
+			await updateNote(id, noteId, { text });
+			setEditingNoteId(null);
+			showToast(t("applicationDetail.toasts.noteUpdated"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
+	}
+
+	async function handleDeleteNote(noteId: string) {
+		if (!id) return;
+		if (!window.confirm(t("applicationDetail.confirmDeleteNote"))) return;
+		try {
+			await deleteNote(id, noteId);
+			showToast(t("applicationDetail.toasts.noteDeleted"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
+		}
+	}
+
+	async function handleUpdateInterview(
+		interviewId: string,
+		round: string,
+		interviewer: string,
+		scheduledAt: string,
+		mode: string,
+		notesText: string
+	) {
+		if (!id) return;
+		try {
+			await updateInterview(id, interviewId, {
+				round,
+				interviewer: interviewer || undefined,
+				scheduledAt: new Date(scheduledAt).toISOString(),
+				mode: mode || undefined,
+				notes: notesText || undefined,
+			});
+			setEditingInterviewId(null);
+			showToast(t("applicationDetail.toasts.interviewUpdated"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
+	}
+
+	async function handleDeleteInterview(interviewId: string) {
+		if (!id) return;
+		if (!window.confirm(t("applicationDetail.confirmDeleteInterview"))) return;
+		try {
+			await deleteInterview(id, interviewId);
+			showToast(t("applicationDetail.toasts.interviewDeleted"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
+		}
+	}
+
+	async function handleUpdateContact(contactId: string, name: string, role: string, email: string) {
+		if (!id) return;
+		try {
+			await updateContact(id, contactId, { name, role: role || undefined, email: email || undefined });
+			setEditingContactId(null);
+			showToast(t("applicationDetail.toasts.contactUpdated"), "success");
+			await refresh();
+		} catch (error) {
+			showToast(t("applications.toasts.error"), "error");
+			throw error;
+		}
+	}
+
+	async function handleDeleteContact(contactId: string) {
+		if (!id) return;
+		if (!window.confirm(t("applicationDetail.confirmDeleteContact"))) return;
+		try {
+			await deleteContact(id, contactId);
+			showToast(t("applicationDetail.toasts.contactDeleted"), "success");
+			await refresh();
+		} catch {
+			showToast(t("applications.toasts.error"), "error");
 		}
 	}
 
@@ -434,29 +551,58 @@ export function ApplicationDetailPage() {
 
 			{tab === "interviews" && (
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-					{interviews.map((iv) => (
-						<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 6 }}>
-							<div style={{ display: "flex", justifyContent: "space-between" }}>
-								<span style={{ fontWeight: 700, fontSize: 14 }}>{iv.round}</span>
-								<span style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
-									{formatDateTime(iv.scheduledAt)}
-								</span>
-							</div>
-							{(iv.interviewer || iv.mode) && (
-								<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
-									{[iv.interviewer, iv.mode].filter(Boolean).join(" · ")}
+					{interviews.map((iv) =>
+						editingInterviewId === iv.id ? (
+							<InterviewForm
+								key={iv.id}
+								initial={iv}
+								onSubmit={(round, interviewer, scheduledAt, mode, notesText) =>
+									handleUpdateInterview(iv.id, round, interviewer, scheduledAt, mode, notesText)
+								}
+								onClose={() => setEditingInterviewId(null)}
+							/>
+						) : (
+							<div key={iv.id} style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: 6 }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+									<span style={{ fontWeight: 700, fontSize: 14 }}>{iv.round}</span>
+									<div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+										<span style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
+											{formatDateTime(iv.scheduledAt)}
+										</span>
+										<KebabMenu
+											ariaLabel={t("applicationDetail.interviewActionsAria", { round: iv.round })}
+											items={[
+												{
+													label: t("common.edit"),
+													onClick: () => {
+														setShowInterviewForm(false);
+														setEditingInterviewId(iv.id);
+													},
+												},
+												{ label: t("common.delete"), onClick: () => handleDeleteInterview(iv.id), variant: "danger" },
+											]}
+										/>
+									</div>
 								</div>
-							)}
-							{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
-						</div>
-					))}
+								{(iv.interviewer || iv.mode) && (
+									<div style={{ fontSize: 12.5, color: "var(--color-text-muted)" }}>
+										{[iv.interviewer, iv.mode].filter(Boolean).join(" · ")}
+									</div>
+								)}
+								{iv.notes && <div style={{ fontSize: 13, color: "oklch(35% 0.012 250)", marginTop: 4 }}>{iv.notes}</div>}
+							</div>
+						)
+					)}
 					{showInterviewForm && (
 						<InterviewForm onSubmit={handleAddInterview} onClose={() => setShowInterviewForm(false)} />
 					)}
 					{interviews.length > 0 && !showInterviewForm && (
 						<div
 							style={addTileStyle}
-							onClick={() => setShowInterviewForm(true)}
+							onClick={() => {
+								setEditingInterviewId(null);
+								setShowInterviewForm(true);
+							}}
 							role="button"
 							aria-label={t("applicationDetail.addInterview")}
 							title={t("applicationDetail.addInterview")}
@@ -481,37 +627,62 @@ export function ApplicationDetailPage() {
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 					{contacts.length > 0 && (
 					<div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 14 }}>
-						{contacts.map((c) => (
-							<div key={c.id} style={{ ...cardStyle, display: "flex", gap: 12, alignItems: "center" }}>
-								<div
-									style={{
-										width: 40,
-										height: 40,
-										borderRadius: "50%",
-										background: "oklch(93% 0.03 35)",
-										flex: "none",
-										display: "flex",
-										alignItems: "center",
-										justifyContent: "center",
-										font: "700 14px var(--font-heading)",
-										color: "oklch(45% 0.11 35)",
-									}}
-								>
-									{c.name.charAt(0).toUpperCase()}
+						{contacts.map((c) =>
+							editingContactId === c.id ? (
+								<ContactForm
+									key={c.id}
+									initial={c}
+									onSubmit={(name, role, email) => handleUpdateContact(c.id, name, role, email)}
+									onClose={() => setEditingContactId(null)}
+								/>
+							) : (
+								<div key={c.id} style={{ ...cardStyle, display: "flex", gap: 12, alignItems: "center" }}>
+									<div
+										style={{
+											width: 40,
+											height: 40,
+											borderRadius: "50%",
+											background: "oklch(93% 0.03 35)",
+											flex: "none",
+											display: "flex",
+											alignItems: "center",
+											justifyContent: "center",
+											font: "700 14px var(--font-heading)",
+											color: "oklch(45% 0.11 35)",
+										}}
+									>
+										{c.name.charAt(0).toUpperCase()}
+									</div>
+									<div style={{ minWidth: 0, flex: 1 }}>
+										<div style={{ fontWeight: 600, fontSize: 13.5 }}>{c.name}</div>
+										{c.role && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.role}</div>}
+										{c.email && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.email}</div>}
+									</div>
+									<KebabMenu
+										ariaLabel={t("applicationDetail.contactActionsAria", { name: c.name })}
+										items={[
+											{
+												label: t("common.edit"),
+												onClick: () => {
+													setShowContactForm(false);
+													setEditingContactId(c.id);
+												},
+											},
+											{ label: t("common.delete"), onClick: () => handleDeleteContact(c.id), variant: "danger" },
+										]}
+									/>
 								</div>
-								<div style={{ minWidth: 0 }}>
-									<div style={{ fontWeight: 600, fontSize: 13.5 }}>{c.name}</div>
-									{c.role && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.role}</div>}
-									{c.email && <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{c.email}</div>}
-								</div>
-							</div>
-						))}
+							)
+						)}
 						{showContactForm ? (
 							<ContactForm onSubmit={handleAddContact} onClose={() => setShowContactForm(false)} />
 						) : (
 							<div
 								style={addTileStyle}
-								onClick={() => setShowContactForm(true)}
+								onClick={() => {
+									setEditingContactId(null);
+									setShowContactForm(true);
+								}}
 								role="button"
 								aria-label={t("applicationDetail.addContact")}
 								title={t("applicationDetail.addContact")}
@@ -539,21 +710,48 @@ export function ApplicationDetailPage() {
 
 			{tab === "notes" && (
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-					{notes.map((n) => (
-						<div key={n.id} style={{ ...cardStyle, padding: "16px 18px" }}>
-							<div style={{ fontSize: 11.5, color: "var(--color-text-faint)", marginBottom: 6 }}>
-								{formatDateTime(n.createdAt)}
+					{notes.map((n) =>
+						editingNoteId === n.id ? (
+							<NoteForm
+								key={n.id}
+								initial={n}
+								onSubmit={(text) => handleUpdateNote(n.id, text)}
+								onClose={() => setEditingNoteId(null)}
+							/>
+						) : (
+							<div key={n.id} style={{ ...cardStyle, padding: "16px 18px" }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+									<div style={{ fontSize: 11.5, color: "var(--color-text-faint)" }}>
+										{formatDateTime(n.createdAt)}
+									</div>
+									<KebabMenu
+										ariaLabel={t("applicationDetail.noteActionsAria")}
+										items={[
+											{
+												label: t("common.edit"),
+												onClick: () => {
+													setShowNoteForm(false);
+													setEditingNoteId(n.id);
+												},
+											},
+											{ label: t("common.delete"), onClick: () => handleDeleteNote(n.id), variant: "danger" },
+										]}
+									/>
+								</div>
+								<div style={{ fontSize: 13.5, color: "oklch(30% 0.012 250)", lineHeight: 1.6, whiteSpace: "pre-line" }}>
+									{n.text}
+								</div>
 							</div>
-							<div style={{ fontSize: 13.5, color: "oklch(30% 0.012 250)", lineHeight: 1.6, whiteSpace: "pre-line" }}>
-								{n.text}
-							</div>
-						</div>
-					))}
+						)
+					)}
 					{showNoteForm && <NoteForm onSubmit={handleAddNote} onClose={() => setShowNoteForm(false)} />}
 					{notes.length > 0 && !showNoteForm && (
 						<div
 							style={addTileStyle}
-							onClick={() => setShowNoteForm(true)}
+							onClick={() => {
+								setEditingNoteId(null);
+								setShowNoteForm(true);
+							}}
 							role="button"
 							aria-label={t("applicationDetail.addNote")}
 							title={t("applicationDetail.addNote")}
@@ -574,14 +772,29 @@ export function ApplicationDetailPage() {
 				</div>
 			)}
 
-			{editing && <ApplicationFormModal initial={application} onSubmit={handleUpdate} onClose={() => setEditing(false)} />}
+			{editing && (
+				<ApplicationFormModal
+					initial={application}
+					onSubmit={handleUpdate}
+					onClose={() => setEditing(false)}
+					onDelete={handleDeleteApplication}
+				/>
+			)}
 		</AppShell>
 	);
 }
 
-function NoteForm({ onSubmit, onClose }: { onSubmit: (text: string) => Promise<void>; onClose: () => void }) {
+function NoteForm({
+	initial,
+	onSubmit,
+	onClose,
+}: {
+	initial?: Note;
+	onSubmit: (text: string) => Promise<void>;
+	onClose: () => void;
+}) {
 	const { t } = useTranslation();
-	const [text, setText] = useState("");
+	const [text, setText] = useState(initial?.text ?? "");
 	const [submitting, setSubmitting] = useState(false);
 
 	async function handleSubmit(e: FormEvent) {
@@ -590,7 +803,7 @@ function NoteForm({ onSubmit, onClose }: { onSubmit: (text: string) => Promise<v
 		setSubmitting(true);
 		try {
 			await onSubmit(text);
-			setText("");
+			if (!initial) setText("");
 		} finally {
 			setSubmitting(false);
 		}
@@ -606,25 +819,27 @@ function NoteForm({ onSubmit, onClose }: { onSubmit: (text: string) => Promise<v
 				style={{ ...inputStyle, minHeight: 70, resize: "vertical" }}
 			/>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				{t("applicationDetail.noteForm.submit")}
+				{initial ? t("applicationDetail.noteForm.saveCta") : t("applicationDetail.noteForm.submit")}
 			</button>
 		</form>
 	);
 }
 
 function InterviewForm({
+	initial,
 	onSubmit,
 	onClose,
 }: {
+	initial?: Interview;
 	onSubmit: (round: string, interviewer: string, scheduledAt: string, mode: string, notes: string) => Promise<void>;
 	onClose: () => void;
 }) {
 	const { t } = useTranslation();
-	const [round, setRound] = useState("");
-	const [interviewer, setInterviewer] = useState("");
-	const [scheduledAt, setScheduledAt] = useState("");
-	const [mode, setMode] = useState("");
-	const [notes, setNotes] = useState("");
+	const [round, setRound] = useState(initial?.round ?? "");
+	const [interviewer, setInterviewer] = useState(initial?.interviewer ?? "");
+	const [scheduledAt, setScheduledAt] = useState(initial ? toDateTimeLocal(initial.scheduledAt) : "");
+	const [mode, setMode] = useState(initial?.mode ?? "");
+	const [notes, setNotes] = useState(initial?.notes ?? "");
 	const [submitting, setSubmitting] = useState(false);
 
 	async function handleSubmit(e: FormEvent) {
@@ -633,11 +848,13 @@ function InterviewForm({
 		setSubmitting(true);
 		try {
 			await onSubmit(round, interviewer, scheduledAt, mode, notes);
-			setRound("");
-			setInterviewer("");
-			setScheduledAt("");
-			setMode("");
-			setNotes("");
+			if (!initial) {
+				setRound("");
+				setInterviewer("");
+				setScheduledAt("");
+				setMode("");
+				setNotes("");
+			}
 		} finally {
 			setSubmitting(false);
 		}
@@ -681,23 +898,25 @@ function InterviewForm({
 				style={inputStyle}
 			/>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				{t("applicationDetail.interviewForm.submit")}
+				{initial ? t("applicationDetail.interviewForm.saveCta") : t("applicationDetail.interviewForm.submit")}
 			</button>
 		</form>
 	);
 }
 
 function ContactForm({
+	initial,
 	onSubmit,
 	onClose,
 }: {
+	initial?: Contact;
 	onSubmit: (name: string, role: string, email: string) => Promise<void>;
 	onClose: () => void;
 }) {
 	const { t } = useTranslation();
-	const [name, setName] = useState("");
-	const [role, setRole] = useState("");
-	const [email, setEmail] = useState("");
+	const [name, setName] = useState(initial?.name ?? "");
+	const [role, setRole] = useState(initial?.role ?? "");
+	const [email, setEmail] = useState(initial?.email ?? "");
 	const [submitting, setSubmitting] = useState(false);
 
 	async function handleSubmit(e: FormEvent) {
@@ -706,9 +925,11 @@ function ContactForm({
 		setSubmitting(true);
 		try {
 			await onSubmit(name, role, email);
-			setName("");
-			setRole("");
-			setEmail("");
+			if (!initial) {
+				setName("");
+				setRole("");
+				setEmail("");
+			}
 		} finally {
 			setSubmitting(false);
 		}
@@ -718,19 +939,21 @@ function ContactForm({
 		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
 			<CloseButton onClick={onClose} />
 			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-				<input
-					required
-					placeholder={t("applicationDetail.contactForm.namePlaceholder")}
-					value={name}
-					onChange={(e) => setName(e.target.value)}
-					style={inputStyle}
-				/>
-				<input
-					placeholder={t("applicationDetail.contactForm.rolePlaceholder")}
-					value={role}
-					onChange={(e) => setRole(e.target.value)}
-					style={inputStyle}
-				/>
+				<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+					<input
+						required
+						placeholder={t("applicationDetail.contactForm.namePlaceholder")}
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						style={inputStyle}
+					/>
+					<input
+						placeholder={t("applicationDetail.contactForm.rolePlaceholder")}
+						value={role}
+						onChange={(e) => setRole(e.target.value)}
+						style={inputStyle}
+					/>
+				</div>
 				<input
 					placeholder={t("applicationDetail.contactForm.emailPlaceholder")}
 					type="email"
@@ -740,7 +963,7 @@ function ContactForm({
 				/>
 			</div>
 			<button type="submit" disabled={submitting} style={addButtonStyle}>
-				{t("applicationDetail.contactForm.submit")}
+				{initial ? t("applicationDetail.contactForm.saveCta") : t("applicationDetail.contactForm.submit")}
 			</button>
 		</form>
 	);

--- a/frontend/src/pages/ApplicationsPage.test.tsx
+++ b/frontend/src/pages/ApplicationsPage.test.tsx
@@ -112,7 +112,8 @@ describe("ApplicationsPage", () => {
 		renderApplicationsPage();
 
 		await screen.findByText("Acme Corp");
-		await userEvent.click(screen.getByLabelText("Delete Acme Corp"));
+		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.deleteApplication).toHaveBeenCalledWith("app-1");

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -12,7 +12,7 @@ import type { Application, ApplicationStatus, CreateApplicationRequest } from ".
 import { AppShell } from "../components/AppShell";
 import { StatusBadge } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
-import { IconButton, PencilIcon, TrashIcon } from "../components/IconButton";
+import { KebabMenu } from "../components/KebabMenu";
 import { ApplicationBoard } from "../components/ApplicationBoard";
 import { useToast } from "../context/ToastContext";
 import { formatDate } from "../utils/date";
@@ -182,6 +182,8 @@ export function ApplicationsPage() {
 					applications={filtered}
 					onStatusChange={handleBoardStatusChange}
 					onAddToStatus={handleAddToStatus}
+					onEdit={setEditing}
+					onDelete={handleDelete}
 				/>
 			) : (
 				<div style={{ background: "#fff", border: "1px solid var(--color-border)", borderRadius: 14, overflowX: "auto" }}>
@@ -283,20 +285,14 @@ export function ApplicationsPage() {
 							<div style={{ color: "var(--color-text-muted)" }}>
 							{app.applicationDate ? formatDate(app.applicationDate) : "—"}
 						</div>
-							<div
-								onClick={(e) => e.stopPropagation()}
-								style={{ display: "flex", gap: 2, justifyContent: "flex-end" }}
-							>
-								<IconButton onClick={() => setEditing(app)} label={t("applications.editAria", { company: app.company })}>
-									<PencilIcon />
-								</IconButton>
-								<IconButton
-									onClick={() => handleDelete(app.id)}
-									label={t("applications.deleteAria", { company: app.company })}
-									variant="danger"
-								>
-									<TrashIcon />
-								</IconButton>
+							<div onClick={(e) => e.stopPropagation()} style={{ display: "flex", justifyContent: "flex-end" }}>
+								<KebabMenu
+									ariaLabel={t("applications.actionsAria", { company: app.company })}
+									items={[
+										{ label: t("common.edit"), onClick: () => setEditing(app) },
+										{ label: t("common.delete"), onClick: () => handleDelete(app.id), variant: "danger" },
+									]}
+								/>
 							</div>
 						</div>
 					))}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -120,10 +120,10 @@ export function DashboardPage() {
 				))}
 			</div>
 
-			<div style={{ display: "grid", gridTemplateColumns: "1.3fr 1fr", gap: 20, alignItems: "start" }}>
-				<div style={cardStyle}>
+			<div style={{ display: "grid", gridTemplateColumns: "1.3fr 1fr", gap: 20, alignItems: "stretch" }}>
+				<div style={{ ...cardStyle, display: "flex", flexDirection: "column", height: 340 }}>
 					<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 16px" }}>{t("dashboard.upcomingInterviews")}</h3>
-					<div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+					<div style={{ display: "flex", flexDirection: "column", gap: 2, overflowY: "auto", flex: 1 }}>
 						{stats.upcomingInterviews.map((iv) => (
 							<div
 								key={`${iv.applicationId}-${iv.scheduledAt}`}
@@ -150,9 +150,9 @@ export function DashboardPage() {
 					</div>
 				</div>
 
-				<div style={cardStyle}>
+				<div style={{ ...cardStyle, display: "flex", flexDirection: "column", height: 340 }}>
 					<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 16px" }}>{t("dashboard.recentActivity")}</h3>
-					<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+					<div style={{ display: "flex", flexDirection: "column", gap: 16, overflowY: "auto", flex: 1 }}>
 						{stats.recentActivity.map((activity) => (
 							<div key={`${activity.applicationId}-${activity.changedAt}`} style={{ display: "flex", gap: 12 }}>
 								<div

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -58,6 +58,8 @@ export interface CreateNoteRequest {
 	text: string;
 }
 
+export type UpdateNoteRequest = Partial<CreateNoteRequest>;
+
 export interface Interview {
 	id: string;
 	round: string;
@@ -76,6 +78,8 @@ export interface CreateInterviewRequest {
 	notes?: string;
 }
 
+export type UpdateInterviewRequest = Partial<CreateInterviewRequest>;
+
 export interface Contact {
 	id: string;
 	name: string;
@@ -89,6 +93,8 @@ export interface CreateContactRequest {
 	role?: string;
 	email?: string;
 }
+
+export type UpdateContactRequest = Partial<CreateContactRequest>;
 
 export interface Page<T> {
 	content: T[];


### PR DESCRIPTION
## Summary
  - Closes #11: interviews, contacts, and notes now support edit and delete (previously create + list only), via new PATCH/DELETE endpoints and ownership-scoped service methods.
  - Introduces a reusable `KebabMenu` component and replaces the pencil/trash icon pairs everywhere (Applications table, board view, detail-page cards) with it.
  - Adds a "Delete application" action inside the edit modal — the detail page previously had no way to delete an application at all.
  - Fixes uneven card heights between "Upcoming interviews" and "Recent activity" on the dashboard.
  - Polish pass on the detail page: tighter title/subtitle spacing, interview card layout (date moved off the title row), 2-column interview edit form, and consistent typography (size/color) for dates
  and meta text across interview, contact, note, and status-history cards.