### PR TITLE
Analytics

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/repository/ApplicationStatusHistoryRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/ApplicationStatusHistoryRepository.kt
@@ -17,4 +17,13 @@ interface ApplicationStatusHistoryRepository : JpaRepository<ApplicationStatusHi
 		"""
 	)
 	fun findRecentByUserId(@Param("userId") userId: UUID): List<ApplicationStatusHistory>
+
+	@Query(
+		"""
+		SELECT h FROM ApplicationStatusHistory h
+		WHERE h.applicationId IN (SELECT a.id FROM Application a WHERE a.userId = :userId)
+		ORDER BY h.applicationId ASC, h.changedAt ASC
+		"""
+	)
+	fun findAllByUserIdOrderByApplicationAndTime(@Param("userId") userId: UUID): List<ApplicationStatusHistory>
 }

--- a/backend/src/main/kotlin/com/nextrole/service/AnalyticsService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/AnalyticsService.kt
@@ -1,0 +1,75 @@
+package com.nextrole.service
+
+import com.nextrole.domain.ApplicationStatus
+import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.ApplicationStatusHistoryRepository
+import com.nextrole.web.dto.AnalyticsResponse
+import com.nextrole.web.dto.FunnelStageCount
+import com.nextrole.web.dto.MonthlyApplicationCount
+import com.nextrole.web.dto.StageConversionRate
+import com.nextrole.web.dto.TechnologyCount
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+import java.time.ZoneOffset
+import java.util.UUID
+
+private const val MONTHS_OF_HISTORY = 6L
+private const val TOP_TECHNOLOGIES_LIMIT = 8
+
+@Service
+class AnalyticsService(
+	private val applicationRepository: ApplicationRepository,
+	private val statusHistoryRepository: ApplicationStatusHistoryRepository
+) {
+
+	fun getAnalytics(userId: UUID): AnalyticsResponse {
+		val applications = applicationRepository.findByUserId(userId)
+
+		val funnelStages = ApplicationStatus.entries.map { status ->
+			FunnelStageCount(status = status, count = applications.count { it.status == status })
+		}
+
+		val currentMonth = YearMonth.now()
+		val months = (MONTHS_OF_HISTORY - 1 downTo 0).map { currentMonth.minusMonths(it) }
+		val applicationsOverTime = months.map { month ->
+			val start = month.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+			val end = month.plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+			val count = applications.count { it.createdAt >= start && it.createdAt < end }
+			MonthlyApplicationCount(month = month.toString(), count = count)
+		}
+
+		val topTechnologies = applications
+			.flatMap { (it.techStack ?: "").split(",").map { tech -> tech.trim() }.filter { tech -> tech.isNotEmpty() } }
+			.groupingBy { it }
+			.eachCount()
+			.entries
+			.sortedByDescending { it.value }
+			.take(TOP_TECHNOLOGIES_LIMIT)
+			.map { TechnologyCount(technology = it.key, count = it.value) }
+
+		val history = statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId)
+		val enteredByStatus = mutableMapOf<ApplicationStatus, Int>()
+		val advancedByStatus = mutableMapOf<ApplicationStatus, Int>()
+		history.groupBy { it.applicationId }.values.forEach { entries ->
+			entries.forEachIndexed { index, entry ->
+				enteredByStatus[entry.status] = (enteredByStatus[entry.status] ?: 0) + 1
+				if (index < entries.size - 1) {
+					advancedByStatus[entry.status] = (advancedByStatus[entry.status] ?: 0) + 1
+				}
+			}
+		}
+		val stageConversionRates = ApplicationStatus.entries.map { status ->
+			val entered = enteredByStatus[status] ?: 0
+			val advanced = advancedByStatus[status] ?: 0
+			val rate = if (entered == 0) 0 else (advanced * 100) / entered
+			StageConversionRate(status = status, conversionRatePercent = rate)
+		}
+
+		return AnalyticsResponse(
+			funnelStages = funnelStages,
+			applicationsOverTime = applicationsOverTime,
+			topTechnologies = topTechnologies,
+			stageConversionRates = stageConversionRates
+		)
+	}
+}

--- a/backend/src/main/kotlin/com/nextrole/service/AnalyticsService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/AnalyticsService.kt
@@ -8,6 +8,7 @@ import com.nextrole.web.dto.FunnelStageCount
 import com.nextrole.web.dto.MonthlyApplicationCount
 import com.nextrole.web.dto.StageConversionRate
 import com.nextrole.web.dto.TechnologyCount
+import com.nextrole.web.dto.WorkModeCount
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.time.ZoneOffset
@@ -15,6 +16,7 @@ import java.util.UUID
 
 private const val MONTHS_OF_HISTORY = 6L
 private const val TOP_TECHNOLOGIES_LIMIT = 8
+private val WORK_MODES = listOf("REMOTE", "HYBRID", "ONSITE")
 
 @Service
 class AnalyticsService(
@@ -31,10 +33,13 @@ class AnalyticsService(
 
 		val currentMonth = YearMonth.now()
 		val months = (MONTHS_OF_HISTORY - 1 downTo 0).map { currentMonth.minusMonths(it) }
+		val appliedApplications = applications.filter { it.status != ApplicationStatus.SAVED }
+		val appliedMonths = appliedApplications.map { application ->
+			application.applicationDate?.let { YearMonth.from(it) }
+				?: YearMonth.from(application.createdAt.atZone(ZoneOffset.UTC))
+		}
 		val applicationsOverTime = months.map { month ->
-			val start = month.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-			val end = month.plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-			val count = applications.count { it.createdAt >= start && it.createdAt < end }
+			val count = appliedMonths.count { it == month }
 			MonthlyApplicationCount(month = month.toString(), count = count)
 		}
 
@@ -65,11 +70,16 @@ class AnalyticsService(
 			StageConversionRate(status = status, conversionRatePercent = rate)
 		}
 
+		val applicationsByWorkMode = WORK_MODES.map { mode ->
+			WorkModeCount(workMode = mode, count = applications.count { it.workMode == mode })
+		}
+
 		return AnalyticsResponse(
 			funnelStages = funnelStages,
 			applicationsOverTime = applicationsOverTime,
 			topTechnologies = topTechnologies,
-			stageConversionRates = stageConversionRates
+			stageConversionRates = stageConversionRates,
+			applicationsByWorkMode = applicationsByWorkMode
 		)
 	}
 }

--- a/backend/src/main/kotlin/com/nextrole/web/AnalyticsController.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/AnalyticsController.kt
@@ -1,0 +1,19 @@
+package com.nextrole.web
+
+import com.nextrole.security.CurrentUser
+import com.nextrole.service.AnalyticsService
+import com.nextrole.web.dto.AnalyticsResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/analytics")
+class AnalyticsController(
+	private val analyticsService: AnalyticsService
+) {
+
+	@GetMapping
+	fun analytics(): AnalyticsResponse =
+		analyticsService.getAnalytics(CurrentUser.id())
+}

--- a/backend/src/main/kotlin/com/nextrole/web/dto/AnalyticsDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/AnalyticsDtos.kt
@@ -1,0 +1,25 @@
+package com.nextrole.web.dto
+
+import com.nextrole.domain.ApplicationStatus
+
+data class MonthlyApplicationCount(
+	val month: String,
+	val count: Int
+)
+
+data class TechnologyCount(
+	val technology: String,
+	val count: Int
+)
+
+data class StageConversionRate(
+	val status: ApplicationStatus,
+	val conversionRatePercent: Int
+)
+
+data class AnalyticsResponse(
+	val funnelStages: List<FunnelStageCount>,
+	val applicationsOverTime: List<MonthlyApplicationCount>,
+	val topTechnologies: List<TechnologyCount>,
+	val stageConversionRates: List<StageConversionRate>
+)

--- a/backend/src/main/kotlin/com/nextrole/web/dto/AnalyticsDtos.kt
+++ b/backend/src/main/kotlin/com/nextrole/web/dto/AnalyticsDtos.kt
@@ -17,9 +17,15 @@ data class StageConversionRate(
 	val conversionRatePercent: Int
 )
 
+data class WorkModeCount(
+	val workMode: String,
+	val count: Int
+)
+
 data class AnalyticsResponse(
 	val funnelStages: List<FunnelStageCount>,
 	val applicationsOverTime: List<MonthlyApplicationCount>,
 	val topTechnologies: List<TechnologyCount>,
-	val stageConversionRates: List<StageConversionRate>
+	val stageConversionRates: List<StageConversionRate>,
+	val applicationsByWorkMode: List<WorkModeCount>
 )

--- a/backend/src/test/kotlin/com/nextrole/service/AnalyticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/AnalyticsServiceTest.kt
@@ -1,0 +1,101 @@
+package com.nextrole.service
+
+import com.nextrole.domain.Application
+import com.nextrole.domain.ApplicationStatus
+import com.nextrole.domain.ApplicationStatusHistory
+import com.nextrole.repository.ApplicationRepository
+import com.nextrole.repository.ApplicationStatusHistoryRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+class AnalyticsServiceTest {
+
+	private val applicationRepository = mockk<ApplicationRepository>()
+	private val statusHistoryRepository = mockk<ApplicationStatusHistoryRepository>()
+	private val analyticsService = AnalyticsService(applicationRepository, statusHistoryRepository)
+	private val userId = UUID.randomUUID()
+
+	private fun application(status: ApplicationStatus, techStack: String? = null, daysOld: Long = 0): Application =
+		Application(
+			userId = userId,
+			company = "Acme",
+			role = "Engineer",
+			status = status,
+			techStack = techStack,
+			createdAt = Instant.now().minus(daysOld, ChronoUnit.DAYS)
+		)
+
+	@Test
+	fun `builds funnel counts across all statuses`() {
+		val applications = listOf(application(ApplicationStatus.APPLIED), application(ApplicationStatus.APPLIED))
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(ApplicationStatus.entries.size, result.funnelStages.size)
+		assertEquals(2, result.funnelStages.first { it.status == ApplicationStatus.APPLIED }.count)
+	}
+
+	@Test
+	fun `buckets applications into their creation month`() {
+		val applications = listOf(application(ApplicationStatus.APPLIED, daysOld = 0))
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(6, result.applicationsOverTime.size)
+		assertEquals(1, result.applicationsOverTime.last().count)
+	}
+
+	@Test
+	fun `counts top technologies across comma-separated tech stacks`() {
+		val applications = listOf(
+			application(ApplicationStatus.APPLIED, techStack = "Kotlin, React"),
+			application(ApplicationStatus.APPLIED, techStack = "Kotlin, Postgres")
+		)
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(2, result.topTechnologies.first { it.technology == "Kotlin" }.count)
+		assertEquals(1, result.topTechnologies.first { it.technology == "React" }.count)
+	}
+
+	@Test
+	fun `computes stage conversion rate as applications that advanced past a stage`() {
+		val advancedApp = UUID.randomUUID()
+		val stalledApp = UUID.randomUUID()
+		val history = listOf(
+			ApplicationStatusHistory(applicationId = advancedApp, status = ApplicationStatus.SAVED, changedAt = Instant.now().minus(10, ChronoUnit.DAYS)),
+			ApplicationStatusHistory(applicationId = advancedApp, status = ApplicationStatus.APPLIED, changedAt = Instant.now().minus(4, ChronoUnit.DAYS)),
+			ApplicationStatusHistory(applicationId = stalledApp, status = ApplicationStatus.SAVED, changedAt = Instant.now().minus(2, ChronoUnit.DAYS))
+		)
+		every { applicationRepository.findByUserId(userId) } returns emptyList()
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns history
+
+		val result = analyticsService.getAnalytics(userId)
+
+		// 2 applications entered SAVED, only 1 advanced past it
+		assertEquals(50, result.stageConversionRates.first { it.status == ApplicationStatus.SAVED }.conversionRatePercent)
+		// 1 application entered APPLIED, none advanced past it yet
+		assertEquals(0, result.stageConversionRates.first { it.status == ApplicationStatus.APPLIED }.conversionRatePercent)
+	}
+
+	@Test
+	fun `returns zero conversion rate for a stage nothing has entered`() {
+		every { applicationRepository.findByUserId(userId) } returns emptyList()
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(0, result.stageConversionRates.first { it.status == ApplicationStatus.OFFER }.conversionRatePercent)
+	}
+}

--- a/backend/src/test/kotlin/com/nextrole/service/AnalyticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/AnalyticsServiceTest.kt
@@ -10,6 +10,8 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.time.LocalDate
+import java.time.YearMonth
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -20,13 +22,21 @@ class AnalyticsServiceTest {
 	private val analyticsService = AnalyticsService(applicationRepository, statusHistoryRepository)
 	private val userId = UUID.randomUUID()
 
-	private fun application(status: ApplicationStatus, techStack: String? = null, daysOld: Long = 0): Application =
+	private fun application(
+		status: ApplicationStatus,
+		techStack: String? = null,
+		workMode: String? = null,
+		daysOld: Long = 0,
+		applicationDate: LocalDate? = null
+	): Application =
 		Application(
 			userId = userId,
 			company = "Acme",
 			role = "Engineer",
 			status = status,
 			techStack = techStack,
+			workMode = workMode,
+			applicationDate = applicationDate,
 			createdAt = Instant.now().minus(daysOld, ChronoUnit.DAYS)
 		)
 
@@ -43,14 +53,40 @@ class AnalyticsServiceTest {
 	}
 
 	@Test
-	fun `buckets applications into their creation month`() {
-		val applications = listOf(application(ApplicationStatus.APPLIED, daysOld = 0))
+	fun `buckets applications by application date when set`() {
+		val threeMonthsAgo = YearMonth.now().minusMonths(3)
+		val applications = listOf(application(ApplicationStatus.APPLIED, applicationDate = threeMonthsAgo.atDay(15)))
 		every { applicationRepository.findByUserId(userId) } returns applications
 		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
 
 		val result = analyticsService.getAnalytics(userId)
 
 		assertEquals(6, result.applicationsOverTime.size)
+		assertEquals(1, result.applicationsOverTime.first { it.month == threeMonthsAgo.toString() }.count)
+	}
+
+	@Test
+	fun `falls back to creation month when application date is not set`() {
+		val applications = listOf(application(ApplicationStatus.APPLIED, daysOld = 0))
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(1, result.applicationsOverTime.last().count)
+	}
+
+	@Test
+	fun `excludes applications still in the saved stage from applications over time`() {
+		val applications = listOf(
+			application(ApplicationStatus.SAVED, daysOld = 0),
+			application(ApplicationStatus.HR_INTERVIEW, daysOld = 0)
+		)
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
 		assertEquals(1, result.applicationsOverTime.last().count)
 	}
 
@@ -97,5 +133,23 @@ class AnalyticsServiceTest {
 		val result = analyticsService.getAnalytics(userId)
 
 		assertEquals(0, result.stageConversionRates.first { it.status == ApplicationStatus.OFFER }.conversionRatePercent)
+	}
+
+	@Test
+	fun `counts applications by work mode`() {
+		val applications = listOf(
+			application(ApplicationStatus.APPLIED, workMode = "REMOTE"),
+			application(ApplicationStatus.APPLIED, workMode = "REMOTE"),
+			application(ApplicationStatus.APPLIED, workMode = "ONSITE"),
+			application(ApplicationStatus.APPLIED, workMode = null)
+		)
+		every { applicationRepository.findByUserId(userId) } returns applications
+		every { statusHistoryRepository.findAllByUserIdOrderByApplicationAndTime(userId) } returns emptyList()
+
+		val result = analyticsService.getAnalytics(userId)
+
+		assertEquals(2, result.applicationsByWorkMode.first { it.workMode == "REMOTE" }.count)
+		assertEquals(1, result.applicationsByWorkMode.first { it.workMode == "ONSITE" }.count)
+		assertEquals(0, result.applicationsByWorkMode.first { it.workMode == "HYBRID" }.count)
 	}
 }

--- a/backend/src/test/kotlin/com/nextrole/web/AnalyticsControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/AnalyticsControllerTest.kt
@@ -45,7 +45,8 @@ class AnalyticsControllerTest {
 			funnelStages = emptyList(),
 			applicationsOverTime = emptyList(),
 			topTechnologies = emptyList(),
-			stageConversionRates = emptyList()
+			stageConversionRates = emptyList(),
+			applicationsByWorkMode = emptyList()
 		)
 
 		mockMvc.get("/api/analytics").andExpect {

--- a/backend/src/test/kotlin/com/nextrole/web/AnalyticsControllerTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/web/AnalyticsControllerTest.kt
@@ -1,0 +1,56 @@
+package com.nextrole.web
+
+import com.ninjasquad.springmockk.MockkBean
+import com.nextrole.service.AnalyticsService
+import com.nextrole.web.dto.AnalyticsResponse
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.util.UUID
+
+@WebMvcTest(AnalyticsController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class AnalyticsControllerTest {
+
+	@Autowired
+	private lateinit var mockMvc: MockMvc
+
+	@MockkBean
+	private lateinit var analyticsService: AnalyticsService
+
+	private val userId = UUID.randomUUID()
+
+	@BeforeEach
+	fun setUp() {
+		val auth = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+		SecurityContextHolder.getContext().authentication = auth
+	}
+
+	@AfterEach
+	fun tearDown() {
+		SecurityContextHolder.clearContext()
+	}
+
+	@Test
+	fun `analytics returns the aggregated summary`() {
+		every { analyticsService.getAnalytics(userId) } returns AnalyticsResponse(
+			funnelStages = emptyList(),
+			applicationsOverTime = emptyList(),
+			topTechnologies = emptyList(),
+			stageConversionRates = emptyList()
+		)
+
+		mockMvc.get("/api/analytics").andExpect {
+			status { isOk() }
+			jsonPath("$.funnelStages") { isEmpty() }
+		}
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthPage } from "./pages/AuthPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { CalendarPage } from "./pages/CalendarPage";
+import { AnalyticsPage } from "./pages/AnalyticsPage";
 import { ApplicationsPage } from "./pages/ApplicationsPage";
 import { ApplicationDetailPage } from "./pages/ApplicationDetailPage";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -23,6 +24,14 @@ export function App() {
 				element={
 					<ProtectedRoute>
 						<CalendarPage />
+					</ProtectedRoute>
+				}
+			/>
+			<Route
+				path="/analytics"
+				element={
+					<ProtectedRoute>
+						<AnalyticsPage />
 					</ProtectedRoute>
 				}
 			/>

--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,7 @@
+import { apiClient } from "./client";
+import type { Analytics } from "../types/analytics";
+
+export async function getAnalytics(): Promise<Analytics> {
+	const response = await apiClient.get<Analytics>("/api/analytics");
+	return response.data;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS: NavItem[] = [
 	{ path: "/dashboard", labelKey: "nav_links.dashboard" },
 	{ path: "/applications", labelKey: "nav_links.applications" },
 	{ path: "/calendar", labelKey: "nav_links.calendar" },
+	{ path: "/analytics", labelKey: "nav_links.analytics" },
 ];
 
 const COLLAPSED_KEY = "nextrole_sidebar_collapsed";

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -41,7 +41,8 @@
 	"nav_links": {
 		"dashboard": "Dashboard",
 		"applications": "Applications",
-		"calendar": "Calendar"
+		"calendar": "Calendar",
+		"analytics": "Analytics"
 	},
 	"calendar": {
 		"title": "Calendar",
@@ -76,6 +77,15 @@
 		"noUpcomingInterviews": "No interviews scheduled.",
 		"noRecentActivity": "No recent activity yet.",
 		"movedTo": "{{company}} moved to {{status}}"
+	},
+	"analytics": {
+		"title": "Analytics",
+		"subtitle": "Trends across your applications",
+		"funnel": "Pipeline funnel",
+		"applicationsOverTime": "Applications over time",
+		"topTechnologies": "Top technologies",
+		"noTechnologies": "No tech stack data yet.",
+		"stageConversionRate": "Stage conversion rate"
 	},
 	"applications": {
 		"title": "Applications",

--- a/frontend/src/pages/AnalyticsPage.test.tsx
+++ b/frontend/src/pages/AnalyticsPage.test.tsx
@@ -31,6 +31,11 @@ const SAMPLE_ANALYTICS: Analytics = {
 		{ status: "SAVED", conversionRatePercent: 50 },
 		{ status: "APPLIED", conversionRatePercent: 25 },
 	],
+	applicationsByWorkMode: [
+		{ workMode: "REMOTE", count: 2 },
+		{ workMode: "HYBRID", count: 0 },
+		{ workMode: "ONSITE", count: 1 },
+	],
 };
 
 function renderAnalytics() {
@@ -63,6 +68,7 @@ describe("AnalyticsPage", () => {
 		expect(screen.getByText("React")).toBeInTheDocument();
 		expect(screen.getAllByText("Saved").length).toBeGreaterThan(0);
 		expect(screen.getByText("50%")).toBeInTheDocument();
+		expect(screen.getByText("Remote")).toBeInTheDocument();
 	});
 
 	it("shows an empty state when there is no tech stack data", async () => {

--- a/frontend/src/pages/AnalyticsPage.test.tsx
+++ b/frontend/src/pages/AnalyticsPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AnalyticsPage } from "./AnalyticsPage";
+import { AuthProvider } from "../context/AuthContext";
+import { ToastProvider } from "../context/ToastContext";
+import * as analyticsApi from "../api/analytics";
+import type { Analytics } from "../types/analytics";
+
+vi.mock("../api/analytics");
+
+const SAMPLE_ANALYTICS: Analytics = {
+	funnelStages: [
+		{ status: "SAVED", count: 1 },
+		{ status: "APPLIED", count: 2 },
+		{ status: "HR_INTERVIEW", count: 0 },
+		{ status: "TECHNICAL", count: 1 },
+		{ status: "FINAL", count: 0 },
+		{ status: "OFFER", count: 0 },
+		{ status: "REJECTED", count: 0 },
+	],
+	applicationsOverTime: [
+		{ month: "2026-03", count: 1 },
+		{ month: "2026-04", count: 2 },
+	],
+	topTechnologies: [
+		{ technology: "Kotlin", count: 3 },
+		{ technology: "React", count: 1 },
+	],
+	stageConversionRates: [
+		{ status: "SAVED", conversionRatePercent: 50 },
+		{ status: "APPLIED", conversionRatePercent: 25 },
+	],
+};
+
+function renderAnalytics() {
+	localStorage.setItem("nextrole_email", "user@example.com");
+	localStorage.setItem("nextrole_token", "fake-token");
+	return render(
+		<MemoryRouter initialEntries={["/analytics"]}>
+			<AuthProvider>
+				<ToastProvider>
+					<Routes>
+						<Route path="/analytics" element={<AnalyticsPage />} />
+					</Routes>
+				</ToastProvider>
+			</AuthProvider>
+		</MemoryRouter>
+	);
+}
+
+describe("AnalyticsPage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.clearAllMocks();
+		vi.mocked(analyticsApi.getAnalytics).mockResolvedValue(SAMPLE_ANALYTICS);
+	});
+
+	it("renders funnel, technologies, and stage conversion rates from the analytics response", async () => {
+		renderAnalytics();
+
+		expect(await screen.findByText("Kotlin")).toBeInTheDocument();
+		expect(screen.getByText("React")).toBeInTheDocument();
+		expect(screen.getAllByText("Saved").length).toBeGreaterThan(0);
+		expect(screen.getByText("50%")).toBeInTheDocument();
+	});
+
+	it("shows an empty state when there is no tech stack data", async () => {
+		vi.mocked(analyticsApi.getAnalytics).mockResolvedValue({ ...SAMPLE_ANALYTICS, topTechnologies: [] });
+		renderAnalytics();
+
+		expect(await screen.findByText("No tech stack data yet.")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -34,6 +34,7 @@ export function AnalyticsPage() {
 	const maxFunnelCount = Math.max(1, ...analytics.funnelStages.map((f) => f.count));
 	const maxMonthlyCount = Math.max(1, ...analytics.applicationsOverTime.map((m) => m.count));
 	const maxTechCount = Math.max(1, ...analytics.topTechnologies.map((tc) => tc.count));
+	const maxWorkModeCount = Math.max(1, ...analytics.applicationsByWorkMode.map((w) => w.count));
 	const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" });
 	const formatMonth = (month: string) => monthFormatter.format(new Date(`${month}-01T00:00:00Z`));
 
@@ -44,7 +45,7 @@ export function AnalyticsPage() {
 				<p style={{ margin: 0, color: "var(--color-text-muted)", fontSize: 14 }}>{t("analytics.subtitle")}</p>
 			</div>
 
-			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
+			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
 				<div style={cardStyle}>
 					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.funnel")}</h3>
 					<div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -110,25 +111,44 @@ export function AnalyticsPage() {
 					</div>
 				</div>
 
-				<div style={cardStyle}>
-					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.applicationsOverTime")}</h3>
-					<div style={{ display: "flex", alignItems: "flex-end", gap: 10, height: 120 }}>
-						{analytics.applicationsOverTime.map((m) => (
-							<div key={m.month} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, height: "100%", justifyContent: "flex-end" }}>
-								<div style={{ fontSize: 10.5, color: "var(--color-text-faint)" }}>{m.count}</div>
-								<div
-									style={{
-										width: "100%",
-										maxWidth: 24,
-										height: `${(m.count / maxMonthlyCount) * 100}%`,
-										minHeight: m.count > 0 ? 4 : 0,
-										borderRadius: "3px 3px 0 0",
-										background: TIME_SERIES_COLOR,
-									}}
-								/>
-								<div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>{formatMonth(m.month)}</div>
-							</div>
-						))}
+				<div style={{ display: "flex", flexDirection: "column", gap: 16, alignSelf: "start" }}>
+					<div style={cardStyle}>
+						<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.applicationsOverTime")}</h3>
+						<div style={{ display: "flex", alignItems: "flex-end", gap: 10, height: 120 }}>
+							{analytics.applicationsOverTime.map((m) => (
+								<div key={m.month} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, height: "100%", justifyContent: "flex-end" }}>
+									<div style={{ fontSize: 10.5, color: "var(--color-text-faint)" }}>{m.count}</div>
+									<div
+										style={{
+											width: "100%",
+											maxWidth: 24,
+											height: `${(m.count / maxMonthlyCount) * 100}%`,
+											minHeight: m.count > 0 ? 4 : 0,
+											borderRadius: "3px 3px 0 0",
+											background: TIME_SERIES_COLOR,
+										}}
+									/>
+									<div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>{formatMonth(m.month)}</div>
+								</div>
+							))}
+						</div>
+					</div>
+
+					<div style={cardStyle}>
+						<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.applicationsByWorkMode")}</h3>
+						<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+							{analytics.applicationsByWorkMode.map((w) => (
+								<div key={w.workMode}>
+									<div style={{ display: "flex", justifyContent: "space-between", marginBottom: 5 }}>
+										<span style={{ fontWeight: 700, fontSize: 12.5 }}>{t(`applicationForm.workModeOptions.${w.workMode}`)}</span>
+										<span style={{ fontSize: 12.5 }}>{w.count}</span>
+									</div>
+									<div style={{ height: 8, borderRadius: 4, background: "oklch(94% 0.005 250)", overflow: "hidden" }}>
+										<div style={{ width: `${(w.count / maxWorkModeCount) * 100}%`, height: "100%", borderRadius: 4, background: TIME_SERIES_COLOR }} />
+									</div>
+								</div>
+							))}
+						</div>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getAnalytics } from "../api/analytics";
+import type { Analytics } from "../types/analytics";
+import { AppShell } from "../components/AppShell";
+import { statusHue } from "../components/StatusBadge";
+
+const cardStyle: React.CSSProperties = {
+	background: "#fff",
+	border: "1px solid var(--color-border)",
+	borderRadius: 14,
+	padding: 16,
+};
+
+const ACCENT = "oklch(65% 0.11 35)";
+const TIME_SERIES_COLOR = "oklch(62% 0.14 255)";
+
+export function AnalyticsPage() {
+	const { t } = useTranslation();
+	const [analytics, setAnalytics] = useState<Analytics | null>(null);
+
+	useEffect(() => {
+		getAnalytics().then(setAnalytics);
+	}, []);
+
+	if (!analytics) {
+		return (
+			<AppShell>
+				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.loading")}</p>
+			</AppShell>
+		);
+	}
+
+	const maxFunnelCount = Math.max(1, ...analytics.funnelStages.map((f) => f.count));
+	const maxMonthlyCount = Math.max(1, ...analytics.applicationsOverTime.map((m) => m.count));
+	const maxTechCount = Math.max(1, ...analytics.topTechnologies.map((tc) => tc.count));
+	const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" });
+	const formatMonth = (month: string) => monthFormatter.format(new Date(`${month}-01T00:00:00Z`));
+
+	return (
+		<AppShell>
+			<div>
+				<h1 style={{ font: "700 26px var(--font-heading)", margin: "0 0 4px" }}>{t("analytics.title")}</h1>
+				<p style={{ margin: 0, color: "var(--color-text-muted)", fontSize: 14 }}>{t("analytics.subtitle")}</p>
+			</div>
+
+			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
+				<div style={cardStyle}>
+					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.funnel")}</h3>
+					<div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+						{analytics.funnelStages.map((f) => (
+							<div key={f.status}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 5 }}>
+									<span style={{ fontWeight: 700, fontSize: 12.5 }}>{t(`status.${f.status}`)}</span>
+									<span style={{ fontSize: 12.5 }}>{f.count}</span>
+								</div>
+								<div style={{ height: 8, borderRadius: 4, background: "oklch(94% 0.005 250)", overflow: "hidden" }}>
+									<div
+										style={{
+											width: `${(f.count / maxFunnelCount) * 100}%`,
+											height: "100%",
+											borderRadius: 4,
+											background: `oklch(60% 0.13 ${statusHue(f.status)})`,
+										}}
+									/>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+
+				<div style={cardStyle}>
+					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.stageConversionRate")}</h3>
+					<div style={{ display: "flex", flexDirection: "column" }}>
+						{analytics.stageConversionRates.map((s, i) => (
+							<div
+								key={s.status}
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "10px 0",
+									borderBottom: i < analytics.stageConversionRates.length - 1 ? "1px solid oklch(94% 0.005 250)" : "none",
+								}}
+							>
+								<span style={{ fontSize: 12.5 }}>{t(`status.${s.status}`)}</span>
+								<span style={{ fontWeight: 700, fontSize: 12.5 }}>{s.conversionRatePercent}%</span>
+							</div>
+						))}
+					</div>
+				</div>
+
+				<div style={cardStyle}>
+					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.topTechnologies")}</h3>
+					<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+						{analytics.topTechnologies.map((tc) => (
+							<div key={tc.technology}>
+								<div style={{ display: "flex", justifyContent: "space-between", marginBottom: 5 }}>
+									<span style={{ fontWeight: 700, fontSize: 12.5 }}>{tc.technology}</span>
+									<span style={{ fontSize: 12.5 }}>{tc.count}</span>
+								</div>
+								<div style={{ height: 8, borderRadius: 4, background: "oklch(94% 0.005 250)", overflow: "hidden" }}>
+									<div style={{ width: `${(tc.count / maxTechCount) * 100}%`, height: "100%", borderRadius: 4, background: ACCENT }} />
+								</div>
+							</div>
+						))}
+						{analytics.topTechnologies.length === 0 && (
+							<p style={{ color: "var(--color-text-muted)", margin: 0, fontSize: 12.5 }}>{t("analytics.noTechnologies")}</p>
+						)}
+					</div>
+				</div>
+
+				<div style={cardStyle}>
+					<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 12px" }}>{t("analytics.applicationsOverTime")}</h3>
+					<div style={{ display: "flex", alignItems: "flex-end", gap: 10, height: 120 }}>
+						{analytics.applicationsOverTime.map((m) => (
+							<div key={m.month} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, height: "100%", justifyContent: "flex-end" }}>
+								<div style={{ fontSize: 10.5, color: "var(--color-text-faint)" }}>{m.count}</div>
+								<div
+									style={{
+										width: "100%",
+										maxWidth: 24,
+										height: `${(m.count / maxMonthlyCount) * 100}%`,
+										minHeight: m.count > 0 ? 4 : 0,
+										borderRadius: "3px 3px 0 0",
+										background: TIME_SERIES_COLOR,
+									}}
+								/>
+								<div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>{formatMonth(m.month)}</div>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+		</AppShell>
+	);
+}

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,0 +1,24 @@
+import type { ApplicationStatus } from "./application";
+import type { FunnelStageCount } from "./dashboard";
+
+export interface MonthlyApplicationCount {
+	month: string;
+	count: number;
+}
+
+export interface TechnologyCount {
+	technology: string;
+	count: number;
+}
+
+export interface StageConversionRate {
+	status: ApplicationStatus;
+	conversionRatePercent: number;
+}
+
+export interface Analytics {
+	funnelStages: FunnelStageCount[];
+	applicationsOverTime: MonthlyApplicationCount[];
+	topTechnologies: TechnologyCount[];
+	stageConversionRates: StageConversionRate[];
+}

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -16,9 +16,15 @@ export interface StageConversionRate {
 	conversionRatePercent: number;
 }
 
+export interface WorkModeCount {
+	workMode: string;
+	count: number;
+}
+
 export interface Analytics {
 	funnelStages: FunnelStageCount[];
 	applicationsOverTime: MonthlyApplicationCount[];
 	topTechnologies: TechnologyCount[];
 	stageConversionRates: StageConversionRate[];
+	applicationsByWorkMode: WorkModeCount[];
 }


### PR DESCRIPTION
- Analytics: a new `GET /api/analytics` endpoint aggregating pipeline funnel counts, applications-over-time, top technologies, stage conversion rate, and applications-by-work-mode.
  - Stage conversion rate replaces a raw avg-days-per-stage metric ( % of applications that advanced past each pipeline stage) which read as more actionable once laid out as a card.
  - Adds the Analytics screen: a 2x2 grid of compact cards (funnel, conversion rate, top technologies, applications over time + work-mode breakdown stacked in one column), wired into routing and the sidebar nav.
    
<img width="1430" height="659" alt="Screenshot 2026-08-20 at 22 40 06" src="https://github.com/user-attachments/assets/fb30e2ef-c03c-4f99-8915-9835cb9244dc" />
