### PR TITLE
 Fix job description capture, stale post-delete empty state, and appl…

### DIFF
--- a/frontend/src/components/ApplicationFormModal.tsx
+++ b/frontend/src/components/ApplicationFormModal.tsx
@@ -64,7 +64,7 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 		techStack: initial?.techStack ?? "",
 		applicationDate: initial?.applicationDate ?? "",
 		status: initial?.status ?? initialStatus ?? "SAVED",
-		notes: initial?.notes ?? "",
+		jobDescription: initial?.jobDescription ?? "",
 	});
 	const [submitting, setSubmitting] = useState(false);
 
@@ -187,18 +187,28 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 						</label>
 					</div>
 					<div style={fieldRowStyle}>
-						<label style={labelStyle}>
-							{t("applicationForm.applicationDate")}
-							<input
-								type="date"
-								value={form.applicationDate ?? ""}
-								onChange={(e) => update("applicationDate", e.target.value)}
-								style={inputStyle}
-							/>
-						</label>
+						{form.status !== "SAVED" && (
+							<label style={labelStyle}>
+								{t("applicationForm.applicationDate")}
+								<input
+									type="date"
+									value={form.applicationDate ?? ""}
+									onChange={(e) => update("applicationDate", e.target.value)}
+									style={inputStyle}
+								/>
+							</label>
+						)}
 						<label style={labelStyle}>
 							{t("applicationForm.status")}
-							<select value={form.status} onChange={(e) => update("status", e.target.value as CreateApplicationRequest["status"])} style={selectStyle}>
+							<select
+								value={form.status}
+								onChange={(e) => {
+									const status = e.target.value as CreateApplicationRequest["status"];
+									update("status", status);
+									if (status === "SAVED") update("applicationDate", "");
+								}}
+								style={selectStyle}
+							>
 								{statusOptions().map((opt) => (
 									<option key={opt.value} value={opt.value}>
 										{opt.label}
@@ -208,10 +218,10 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 						</label>
 					</div>
 					<label style={labelStyle}>
-						{t("applicationForm.notes")}
+						{t("applicationForm.jobDescription")}
 						<textarea
-							value={form.notes ?? ""}
-							onChange={(e) => update("notes", e.target.value)}
+							value={form.jobDescription ?? ""}
+							onChange={(e) => update("jobDescription", e.target.value)}
 							style={{ ...inputStyle, minHeight: 70, resize: "vertical" }}
 						/>
 					</label>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -85,7 +85,8 @@
 		"applicationsOverTime": "Applications over time",
 		"topTechnologies": "Top technologies",
 		"noTechnologies": "No tech stack data yet.",
-		"stageConversionRate": "Stage conversion rate"
+		"stageConversionRate": "Stage conversion rate",
+		"applicationsByWorkMode": "Applications by work mode"
 	},
 	"applications": {
 		"title": "Applications",
@@ -95,6 +96,8 @@
 		"tableView": "Table",
 		"loading": "Loading…",
 		"empty": "No applications yet. Add your first one.",
+		"emptySearch": "No applications match your search.",
+		"clearSearch": "Clear search",
 		"confirmDelete": "Delete this application?",
 		"actionsAria": "Actions for {{company}}",
 		"toasts": {
@@ -132,7 +135,7 @@
 		"techStack": "Tech stack (comma-separated)",
 		"applicationDate": "Application date",
 		"status": "Status",
-		"notes": "Notes",
+		"jobDescription": "Job description",
 		"cancel": "Cancel",
 		"createCta": "Create application",
 		"saveCta": "Save changes",

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -66,6 +66,16 @@ describe("ApplicationDetailPage", () => {
 		expect(await screen.findByRole("heading", { name: "Backend Engineer" })).toBeInTheDocument();
 		expect(screen.getByText("Build great APIs.")).toBeInTheDocument();
 		expect(screen.getByText("Kotlin")).toBeInTheDocument();
+		expect(screen.getByText("Applied: Aug 1, 2026")).toBeInTheDocument();
+	});
+
+	it("shows 'Not applied yet' when still in the saved stage, even if an application date is set", async () => {
+		vi.mocked(applicationsApi.getApplication).mockResolvedValue({ ...SAMPLE_APPLICATION, status: "SAVED" });
+		renderDetailPage();
+
+		expect(await screen.findByRole("heading", { name: "Backend Engineer" })).toBeInTheDocument();
+		expect(screen.getByText("Not applied yet")).toBeInTheDocument();
+		expect(screen.queryByText("Applied: Aug 1, 2026")).not.toBeInTheDocument();
 	});
 
 	it("switches to the status history tab", async () => {

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -507,7 +507,7 @@ export function ApplicationDetailPage() {
 							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 8px" }}>{t("applicationDetail.keyDates")}</h3>
 							<div style={{ fontSize: 13, color: "oklch(40% 0.012 250)", display: "flex", flexDirection: "column", gap: 6 }}>
 								<div>
-									{application.applicationDate
+									{application.status !== "SAVED" && application.applicationDate
 										? t("applicationDetail.applied", { date: formatDate(application.applicationDate) })
 										: t("applicationDetail.notAppliedYet")}
 								</div>

--- a/frontend/src/pages/ApplicationsPage.test.tsx
+++ b/frontend/src/pages/ApplicationsPage.test.tsx
@@ -119,4 +119,26 @@ describe("ApplicationsPage", () => {
 			expect(applicationsApi.deleteApplication).toHaveBeenCalledWith("app-1");
 		});
 	});
+
+	it("shows a search-specific empty state, not the generic one, when a search filter has no matches after a delete", async () => {
+		const other: Application = { ...SAMPLE_APPLICATION, id: "app-2", company: "Globex", role: "Frontend Engineer" };
+		vi.mocked(applicationsApi.listApplications)
+			.mockResolvedValueOnce(samplePage([SAMPLE_APPLICATION, other]))
+			.mockResolvedValueOnce(samplePage([other]));
+		vi.mocked(applicationsApi.deleteApplication).mockResolvedValue(undefined);
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		renderApplicationsPage();
+
+		await screen.findByText("Acme Corp");
+		await userEvent.type(screen.getByPlaceholderText("Search company or role"), "Acme");
+		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+		expect(await screen.findByText("No applications match your search.", { exact: false })).toBeInTheDocument();
+		expect(screen.queryByText("No applications yet. Add your first one.")).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByText("Clear search"));
+
+		expect(await screen.findByText("Globex")).toBeInTheDocument();
+	});
 });

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -175,8 +175,15 @@ export function ApplicationsPage() {
 
 			{loading ? (
 				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.loading")}</p>
-			) : filtered.length === 0 ? (
+			) : applications.length === 0 ? (
 				<p style={{ color: "var(--color-text-muted)" }}>{t("applications.empty")}</p>
+			) : filtered.length === 0 ? (
+				<p style={{ color: "var(--color-text-muted)" }}>
+					{t("applications.emptySearch")}{" "}
+					<a href="#" onClick={(e) => { e.preventDefault(); setSearch(""); }}>
+						{t("applications.clearSearch")}
+					</a>
+				</p>
 			) : view === "board" ? (
 				<ApplicationBoard
 					applications={filtered}


### PR DESCRIPTION
- Form's "job description" textarea now writes to `jobDescription` (already displayed on the detail page's Overview tab) instead of the unused `notes` field, which had no display location anywhere.
- Fixes #18: deleting the only application matching an active search filter showed the generic "No applications yet" empty state even though other applications existed — it only "resolved" on a manual reload because that reset the search box. Now shows a search-specific empty state with a "Clear search" action instead.
  - "Applied: {date}" no longer shows on the detail page while an application is still in the Saved stage (previously it showed regardless of status, as long as `applicationDate` happened to be set). The form now hides the Application date 
field until status moves past Saved, and clears it if you switch back, so the field and the status badge can't disagree.