### PR TITLE
Detail page ux improvements

### DIFF
--- a/backend/src/main/kotlin/com/nextrole/repository/NoteRepository.kt
+++ b/backend/src/main/kotlin/com/nextrole/repository/NoteRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface NoteRepository : JpaRepository<Note, UUID> {
-    fun findByApplicationIdOrderByCreatedAtAsc(applicationId: UUID): List<Note>
+    fun findByApplicationIdOrderByCreatedAtDesc(applicationId: UUID): List<Note>
 }

--- a/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
+++ b/backend/src/main/kotlin/com/nextrole/service/NoteService.kt
@@ -22,7 +22,7 @@ class NoteService(
 
     fun list(userId: UUID, applicationId: UUID): List<Note> {
         applicationService.get(userId, applicationId)
-        return noteRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId)
+        return noteRepository.findByApplicationIdOrderByCreatedAtDesc(applicationId)
     }
 
     fun update(userId: UUID, applicationId: UUID, noteId: UUID, request: UpdateNoteRequest): Note {

--- a/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
+++ b/backend/src/test/kotlin/com/nextrole/service/NoteServiceTest.kt
@@ -51,7 +51,7 @@ class NoteServiceTest {
 	fun `list returns notes for an owned application`() {
 		every { applicationService.get(userId, applicationId) } returns mockk<Application>()
 		val notes = listOf(Note(applicationId = applicationId, text = "First note"))
-		every { noteRepository.findByApplicationIdOrderByCreatedAtAsc(applicationId) } returns notes
+		every { noteRepository.findByApplicationIdOrderByCreatedAtDesc(applicationId) } returns notes
 
 		val result = noteService.list(userId, applicationId)
 

--- a/frontend/src/components/ApplicationFormModal.tsx
+++ b/frontend/src/components/ApplicationFormModal.tsx
@@ -97,7 +97,6 @@ export function ApplicationFormModal({ initial, initialStatus, onSubmit, onClose
 				padding: 24,
 				zIndex: 10,
 			}}
-			onClick={onClose}
 		>
 			<div
 				onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/AutoGrowTextarea.tsx
+++ b/frontend/src/components/AutoGrowTextarea.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from "react";
+
+type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function AutoGrowTextarea({ value, style, ...rest }: Props) {
+	const ref = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		el.style.height = "auto";
+		el.style.height = `${el.scrollHeight}px`;
+	}, [value]);
+
+	return <textarea ref={ref} value={value} style={{ ...style, overflow: "hidden" }} {...rest} />;
+}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,103 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface ConfirmDialogProps {
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+	const { t } = useTranslation();
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			style={{
+				position: "fixed",
+				inset: 0,
+				background: "oklch(22% 0.014 250 / 0.35)",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 24,
+				zIndex: 20,
+			}}
+			onClick={onCancel}
+		>
+			<div
+				onClick={(e) => e.stopPropagation()}
+				style={{
+					background: "#fff",
+					borderRadius: 16,
+					padding: 24,
+					width: "100%",
+					maxWidth: 380,
+					display: "flex",
+					flexDirection: "column",
+					gap: 18,
+				}}
+			>
+				<p style={{ margin: 0, fontSize: 14, lineHeight: 1.5, color: "var(--color-text)" }}>{message}</p>
+				<div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+					<button
+						type="button"
+						onClick={onCancel}
+						style={{
+							border: "1px solid var(--color-border)",
+							borderRadius: 10,
+							padding: "9px 16px",
+							background: "#fff",
+							color: "var(--color-text)",
+							font: "600 13px var(--font-body)",
+							cursor: "pointer",
+						}}
+					>
+						{t("common.cancel")}
+					</button>
+					<button
+						type="button"
+						onClick={onConfirm}
+						style={{
+							border: "none",
+							borderRadius: 10,
+							padding: "9px 16px",
+							background: "oklch(50% 0.15 30)",
+							color: "#fff",
+							font: "600 13px var(--font-body)",
+							cursor: "pointer",
+						}}
+					>
+						{t("common.delete")}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function useConfirm() {
+	const [message, setMessage] = useState<string | null>(null);
+	const resolver = useRef<((value: boolean) => void) | null>(null);
+
+	function confirm(msg: string): Promise<boolean> {
+		setMessage(msg);
+		return new Promise((resolve) => {
+			resolver.current = resolve;
+		});
+	}
+
+	function handleConfirm() {
+		resolver.current?.(true);
+		setMessage(null);
+	}
+
+	function handleCancel() {
+		resolver.current?.(false);
+		setMessage(null);
+	}
+
+	const dialog = message !== null ? <ConfirmDialog message={message} onConfirm={handleConfirm} onCancel={handleCancel} /> : null;
+
+	return { confirm, dialog };
+}

--- a/frontend/src/components/FormattedText.test.tsx
+++ b/frontend/src/components/FormattedText.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormattedText } from "./FormattedText";
+
+describe("FormattedText", () => {
+	it("renders bold segments marked with **", () => {
+		render(<FormattedText text="This role needs **Kotlin** and **Spring Boot**." />);
+
+		expect(screen.getByText("Kotlin", { selector: "strong" })).toBeInTheDocument();
+		expect(screen.getByText("Spring Boot", { selector: "strong" })).toBeInTheDocument();
+	});
+
+	it("renders a bullet list from dash-prefixed lines", () => {
+		render(<FormattedText text={"Requirements:\n- Kotlin\n- PostgreSQL\n- Docker"} />);
+
+		const list = screen.getByText("Kotlin").closest("ul");
+		expect(list).toBeInTheDocument();
+		expect(screen.getByText("PostgreSQL").tagName).toBe("LI");
+		expect(screen.getByText("Docker").tagName).toBe("LI");
+	});
+
+	it("renders a numbered list from digit-prefixed lines", () => {
+		render(<FormattedText text={"1. First step\n2. Second step"} />);
+
+		const list = screen.getByText("First step").closest("ol");
+		expect(list).toBeInTheDocument();
+		expect(screen.getByText("Second step").tagName).toBe("LI");
+	});
+
+	it("renders plain lines untouched when there is no markup", () => {
+		render(<FormattedText text={"Line one\nLine two"} />);
+
+		expect(screen.getByText("Line one")).toBeInTheDocument();
+		expect(screen.getByText("Line two")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/FormattedText.tsx
+++ b/frontend/src/components/FormattedText.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+const BULLET_RE = /^[-*]\s+(.*)/;
+const NUMBERED_RE = /^\d+[.)]\s+(.*)/;
+const listStyle: React.CSSProperties = { margin: "4px 0", paddingLeft: 20 };
+
+function parseInline(text: string): ReactNode[] {
+	return text.split(/(\*\*[^*]+\*\*)/g).map((part, i) =>
+		part.startsWith("**") && part.endsWith("**") && part.length > 4 ? <strong key={i}>{part.slice(2, -2)}</strong> : part
+	);
+}
+
+export function FormattedText({ text }: { text: string }) {
+	const lines = text.split("\n");
+	const blocks: ReactNode[] = [];
+	let listItems: string[] = [];
+	let listType: "ul" | "ol" | null = null;
+
+	function flushList() {
+		if (listItems.length) {
+			const items = listItems.map((item, i) => <li key={i}>{parseInline(item)}</li>);
+			blocks.push(
+				listType === "ol" ? (
+					<ol key={`list-${blocks.length}`} style={listStyle}>
+						{items}
+					</ol>
+				) : (
+					<ul key={`list-${blocks.length}`} style={listStyle}>
+						{items}
+					</ul>
+				)
+			);
+		}
+		listItems = [];
+		listType = null;
+	}
+
+	lines.forEach((line, i) => {
+		const bulletMatch = BULLET_RE.exec(line);
+		const numberedMatch = NUMBERED_RE.exec(line);
+		if (bulletMatch) {
+			if (listType !== "ul") flushList();
+			listType = "ul";
+			listItems.push(bulletMatch[1]);
+		} else if (numberedMatch) {
+			if (listType !== "ol") flushList();
+			listType = "ol";
+			listItems.push(numberedMatch[1]);
+		} else {
+			flushList();
+			blocks.push(line.trim() === "" ? <div key={`sp-${i}`} style={{ height: 8 }} /> : <div key={`line-${i}`}>{parseInline(line)}</div>);
+		}
+	});
+	flushList();
+
+	return <>{blocks}</>;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -5,7 +5,8 @@
 	"common": {
 		"actions": "Actions",
 		"edit": "Edit",
-		"delete": "Delete"
+		"delete": "Delete",
+		"cancel": "Cancel"
 	},
 	"nav": {
 		"logOut": "Log out",
@@ -162,6 +163,10 @@
 		"noInterviews": "No interviews scheduled yet.",
 		"noContacts": "No contacts saved yet.",
 		"noNotes": "No notes yet.",
+		"notesSort": {
+			"newestFirst": "Newest first",
+			"oldestFirst": "Oldest first"
+		},
 		"addInterview": "Add interview",
 		"addContact": "Add contact",
 		"addNote": "Add note",

--- a/frontend/src/pages/ApplicationDetailPage.test.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.test.tsx
@@ -78,6 +78,30 @@ describe("ApplicationDetailPage", () => {
 		expect(screen.queryByText("Applied: Aug 1, 2026")).not.toBeInTheDocument();
 	});
 
+	it("edits the job description inline from the overview tab", async () => {
+		const updated = { ...SAMPLE_APPLICATION, jobDescription: "Build great APIs, remotely." };
+		vi.mocked(applicationsApi.updateApplication).mockResolvedValue(updated);
+		vi.mocked(applicationsApi.getApplication)
+			.mockResolvedValueOnce(SAMPLE_APPLICATION)
+			.mockResolvedValueOnce(updated);
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByLabelText("Edit"));
+
+		const textarea = screen.getByDisplayValue("Build great APIs.");
+		await userEvent.clear(textarea);
+		await userEvent.type(textarea, "Build great APIs, remotely.");
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => {
+			expect(applicationsApi.updateApplication).toHaveBeenCalledWith("app-1", {
+				jobDescription: "Build great APIs, remotely.",
+			});
+		});
+		expect(await screen.findByText("Build great APIs, remotely.")).toBeInTheDocument();
+	});
+
 	it("switches to the status history tab", async () => {
 		renderDetailPage();
 
@@ -195,17 +219,40 @@ describe("ApplicationDetailPage", () => {
 		const existingNote: Note = { id: "n1", text: "First call went well.", createdAt: "2026-08-01T00:00:00Z" };
 		vi.mocked(applicationsApi.listNotes).mockResolvedValue([existingNote]);
 		vi.mocked(applicationsApi.deleteNote).mockResolvedValue(undefined);
-		vi.spyOn(window, "confirm").mockReturnValue(true);
 		renderDetailPage();
 
 		await screen.findByRole("heading", { name: "Backend Engineer" });
 		await userEvent.click(screen.getByText("Notes"));
 		await userEvent.click(screen.getByLabelText("Note actions"));
 		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.deleteNote).toHaveBeenCalledWith("app-1", "n1");
 		});
+	});
+
+	it("toggles note sort order between newest and oldest first", async () => {
+		const notes: Note[] = [
+			{ id: "n1", text: "Newest note", createdAt: "2026-08-03T00:00:00Z" },
+			{ id: "n2", text: "Oldest note", createdAt: "2026-08-01T00:00:00Z" },
+		];
+		vi.mocked(applicationsApi.listNotes).mockResolvedValue(notes);
+		renderDetailPage();
+
+		await screen.findByRole("heading", { name: "Backend Engineer" });
+		await userEvent.click(screen.getByText("Notes"));
+
+		const getNoteOrder = () => screen.getAllByText(/Newest note|Oldest note/).map((el) => el.textContent);
+		expect(getNoteOrder()).toEqual(["Newest note", "Oldest note"]);
+		expect(screen.getByRole("button", { name: /Newest first/ })).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: /Newest first/ }));
+		expect(getNoteOrder()).toEqual(["Oldest note", "Newest note"]);
+		expect(screen.getByRole("button", { name: /Oldest first/ })).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: /Oldest first/ }));
+		expect(getNoteOrder()).toEqual(["Newest note", "Oldest note"]);
 	});
 
 	it("edits an existing contact", async () => {
@@ -245,13 +292,13 @@ describe("ApplicationDetailPage", () => {
 		};
 		vi.mocked(applicationsApi.listInterviews).mockResolvedValue([existingInterview]);
 		vi.mocked(applicationsApi.deleteInterview).mockResolvedValue(undefined);
-		vi.spyOn(window, "confirm").mockReturnValue(true);
 		renderDetailPage();
 
 		await screen.findByRole("heading", { name: "Backend Engineer" });
 		await userEvent.click(screen.getByText("Interviews"));
 		await userEvent.click(screen.getByLabelText("Actions for HR Screen"));
 		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.deleteInterview).toHaveBeenCalledWith("app-1", "iv1");

--- a/frontend/src/pages/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/ApplicationDetailPage.tsx
@@ -24,16 +24,19 @@ import type {
 	Application,
 	ApplicationStatus,
 	Contact,
-	CreateApplicationRequest,
 	Interview,
 	Note,
 	StatusHistoryEntry,
+	UpdateApplicationRequest,
 } from "../types/application";
 import { AppShell } from "../components/AppShell";
 import { StatusBadge, statusOptions } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
+import { AutoGrowTextarea } from "../components/AutoGrowTextarea";
 import { CloseButton } from "../components/CloseButton";
-import { PlusIcon } from "../components/IconButton";
+import { useConfirm } from "../components/ConfirmDialog";
+import { FormattedText } from "../components/FormattedText";
+import { IconButton, PencilIcon, PlusIcon } from "../components/IconButton";
 import { KebabMenu } from "../components/KebabMenu";
 import { useToast } from "../context/ToastContext";
 import { formatDate, formatDateTime } from "../utils/date";
@@ -141,6 +144,9 @@ export function ApplicationDetailPage() {
 	const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
 	const [editingInterviewId, setEditingInterviewId] = useState<string | null>(null);
 	const [editingContactId, setEditingContactId] = useState<string | null>(null);
+	const [editingJobDescription, setEditingJobDescription] = useState(false);
+	const [noteSortOrder, setNoteSortOrder] = useState<"newest" | "oldest">("newest");
+	const { confirm, dialog: confirmDialog } = useConfirm();
 
 	async function refresh() {
 		if (!id) return;
@@ -163,7 +169,7 @@ export function ApplicationDetailPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [id]);
 
-	async function handleUpdate(request: CreateApplicationRequest) {
+	async function handleUpdate(request: UpdateApplicationRequest) {
 		if (!id) return;
 		try {
 			await updateApplication(id, request);
@@ -175,9 +181,14 @@ export function ApplicationDetailPage() {
 		}
 	}
 
+	async function handleUpdateJobDescription(jobDescription: string) {
+		await handleUpdate({ jobDescription });
+		setEditingJobDescription(false);
+	}
+
 	async function handleDeleteApplication() {
 		if (!id) return;
-		if (!window.confirm(t("applications.confirmDelete"))) return;
+		if (!(await confirm(t("applications.confirmDelete")))) return;
 		try {
 			await deleteApplication(id);
 			showToast(t("applications.toasts.deleted"), "success");
@@ -259,7 +270,7 @@ export function ApplicationDetailPage() {
 
 	async function handleDeleteNote(noteId: string) {
 		if (!id) return;
-		if (!window.confirm(t("applicationDetail.confirmDeleteNote"))) return;
+		if (!(await confirm(t("applicationDetail.confirmDeleteNote")))) return;
 		try {
 			await deleteNote(id, noteId);
 			showToast(t("applicationDetail.toasts.noteDeleted"), "success");
@@ -297,7 +308,7 @@ export function ApplicationDetailPage() {
 
 	async function handleDeleteInterview(interviewId: string) {
 		if (!id) return;
-		if (!window.confirm(t("applicationDetail.confirmDeleteInterview"))) return;
+		if (!(await confirm(t("applicationDetail.confirmDeleteInterview")))) return;
 		try {
 			await deleteInterview(id, interviewId);
 			showToast(t("applicationDetail.toasts.interviewDeleted"), "success");
@@ -322,7 +333,7 @@ export function ApplicationDetailPage() {
 
 	async function handleDeleteContact(contactId: string) {
 		if (!id) return;
-		if (!window.confirm(t("applicationDetail.confirmDeleteContact"))) return;
+		if (!(await confirm(t("applicationDetail.confirmDeleteContact")))) return;
 		try {
 			await deleteContact(id, contactId);
 			showToast(t("applicationDetail.toasts.contactDeleted"), "success");
@@ -474,12 +485,25 @@ export function ApplicationDetailPage() {
 
 			{tab === "overview" && (
 				<div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 20, alignItems: "start" }}>
-					<div style={cardStyle}>
-						<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 0 12px" }}>{t("applicationDetail.jobDescription")}</h3>
-						<p style={{ fontSize: 13.5, lineHeight: 1.7, color: "oklch(30% 0.012 250)", whiteSpace: "pre-line" }}>
-							{application.jobDescription || t("applicationDetail.noJobDescription")}
-						</p>
-					</div>
+					{editingJobDescription ? (
+						<JobDescriptionForm
+							initial={application.jobDescription ?? ""}
+							onSubmit={handleUpdateJobDescription}
+							onClose={() => setEditingJobDescription(false)}
+						/>
+					) : (
+						<div style={cardStyle}>
+							<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+								<h3 style={{ font: "700 15px var(--font-heading)", margin: 0 }}>{t("applicationDetail.jobDescription")}</h3>
+								<IconButton onClick={() => setEditingJobDescription(true)} label={t("common.edit")}>
+									<PencilIcon />
+								</IconButton>
+							</div>
+							<div style={{ fontSize: 13.5, lineHeight: 1.7, color: "oklch(30% 0.012 250)" }}>
+								{application.jobDescription ? <FormattedText text={application.jobDescription} /> : t("applicationDetail.noJobDescription")}
+							</div>
+						</div>
+					)}
 					<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 						<div style={cardStyle}>
 							<h3 style={{ font: "700 14px var(--font-heading)", margin: "0 0 10px" }}>{t("applicationDetail.techStack")}</h3>
@@ -708,7 +732,28 @@ export function ApplicationDetailPage() {
 
 			{tab === "notes" && (
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-					{notes.map((n) =>
+					{notes.length > 0 && (
+						<button
+							type="button"
+							onClick={() => setNoteSortOrder((order) => (order === "newest" ? "oldest" : "newest"))}
+							style={{
+								alignSelf: "flex-end",
+								display: "flex",
+								alignItems: "center",
+								gap: 5,
+								border: "none",
+								background: "transparent",
+								color: "var(--color-text-muted)",
+								font: "600 12px var(--font-body)",
+								cursor: "pointer",
+								padding: 0,
+							}}
+						>
+							<span aria-hidden="true">⇅</span>
+							{noteSortOrder === "newest" ? t("applicationDetail.notesSort.newestFirst") : t("applicationDetail.notesSort.oldestFirst")}
+						</button>
+					)}
+					{(noteSortOrder === "newest" ? notes : [...notes].reverse()).map((n) =>
 						editingNoteId === n.id ? (
 							<NoteForm
 								key={n.id}
@@ -736,8 +781,8 @@ export function ApplicationDetailPage() {
 										]}
 									/>
 								</div>
-								<div style={{ fontSize: 13.5, color: "oklch(30% 0.012 250)", lineHeight: 1.6, whiteSpace: "pre-line" }}>
-									{n.text}
+								<div style={{ fontSize: 13.5, color: "oklch(30% 0.012 250)", lineHeight: 1.6 }}>
+									<FormattedText text={n.text} />
 								</div>
 							</div>
 						)
@@ -778,7 +823,48 @@ export function ApplicationDetailPage() {
 					onDelete={handleDeleteApplication}
 				/>
 			)}
+			{confirmDialog}
 		</AppShell>
+	);
+}
+
+function JobDescriptionForm({
+	initial,
+	onSubmit,
+	onClose,
+}: {
+	initial: string;
+	onSubmit: (text: string) => Promise<void>;
+	onClose: () => void;
+}) {
+	const { t } = useTranslation();
+	const [text, setText] = useState(initial);
+	const [submitting, setSubmitting] = useState(false);
+
+	async function handleSubmit(e: FormEvent) {
+		e.preventDefault();
+		setSubmitting(true);
+		try {
+			await onSubmit(text);
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", display: "flex", flexDirection: "column", gap: 10 }}>
+			<CloseButton onClick={onClose} />
+			<h3 style={{ font: "700 15px var(--font-heading)", margin: "0 24px 0 0" }}>{t("applicationDetail.jobDescription")}</h3>
+			<AutoGrowTextarea
+				value={text}
+				onChange={(e) => setText(e.target.value)}
+				style={{ ...inputStyle, minHeight: 160, resize: "vertical" }}
+				autoFocus
+			/>
+			<button type="submit" disabled={submitting} style={addButtonStyle}>
+				{t("applicationForm.saveCta")}
+			</button>
+		</form>
 	);
 }
 
@@ -810,7 +896,7 @@ function NoteForm({
 	return (
 		<form onSubmit={handleSubmit} style={{ ...cardStyle, position: "relative", paddingTop: 44, display: "flex", flexDirection: "column", gap: 10 }}>
 			<CloseButton onClick={onClose} />
-			<textarea
+			<AutoGrowTextarea
 				value={text}
 				onChange={(e) => setText(e.target.value)}
 				placeholder={t("applicationDetail.noteForm.placeholder")}

--- a/frontend/src/pages/ApplicationsPage.test.tsx
+++ b/frontend/src/pages/ApplicationsPage.test.tsx
@@ -108,16 +108,29 @@ describe("ApplicationsPage", () => {
 	it("deletes an application after confirmation", async () => {
 		vi.mocked(applicationsApi.listApplications).mockResolvedValue(samplePage());
 		vi.mocked(applicationsApi.deleteApplication).mockResolvedValue(undefined);
-		vi.spyOn(window, "confirm").mockReturnValue(true);
 		renderApplicationsPage();
 
 		await screen.findByText("Acme Corp");
 		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
 		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
 
 		await waitFor(() => {
 			expect(applicationsApi.deleteApplication).toHaveBeenCalledWith("app-1");
 		});
+	});
+
+	it("does not delete when the confirm dialog is cancelled", async () => {
+		vi.mocked(applicationsApi.listApplications).mockResolvedValue(samplePage());
+		vi.mocked(applicationsApi.deleteApplication).mockResolvedValue(undefined);
+		renderApplicationsPage();
+
+		await screen.findByText("Acme Corp");
+		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
+		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		await userEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+		expect(applicationsApi.deleteApplication).not.toHaveBeenCalled();
 	});
 
 	it("shows a search-specific empty state, not the generic one, when a search filter has no matches after a delete", async () => {
@@ -126,13 +139,13 @@ describe("ApplicationsPage", () => {
 			.mockResolvedValueOnce(samplePage([SAMPLE_APPLICATION, other]))
 			.mockResolvedValueOnce(samplePage([other]));
 		vi.mocked(applicationsApi.deleteApplication).mockResolvedValue(undefined);
-		vi.spyOn(window, "confirm").mockReturnValue(true);
 		renderApplicationsPage();
 
 		await screen.findByText("Acme Corp");
 		await userEvent.type(screen.getByPlaceholderText("Search company or role"), "Acme");
 		await userEvent.click(screen.getByLabelText("Actions for Acme Corp"));
 		await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+		await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
 
 		expect(await screen.findByText("No applications match your search.", { exact: false })).toBeInTheDocument();
 		expect(screen.queryByText("No applications yet. Add your first one.")).not.toBeInTheDocument();

--- a/frontend/src/pages/ApplicationsPage.tsx
+++ b/frontend/src/pages/ApplicationsPage.tsx
@@ -12,6 +12,7 @@ import type { Application, ApplicationStatus, CreateApplicationRequest } from ".
 import { AppShell } from "../components/AppShell";
 import { StatusBadge } from "../components/StatusBadge";
 import { ApplicationFormModal } from "../components/ApplicationFormModal";
+import { useConfirm } from "../components/ConfirmDialog";
 import { KebabMenu } from "../components/KebabMenu";
 import { ApplicationBoard } from "../components/ApplicationBoard";
 import { useToast } from "../context/ToastContext";
@@ -31,6 +32,7 @@ export function ApplicationsPage() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const { showToast } = useToast();
+	const { confirm, dialog: confirmDialog } = useConfirm();
 	const [applications, setApplications] = useState<Application[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [search, setSearch] = useState("");
@@ -87,7 +89,7 @@ export function ApplicationsPage() {
 	}
 
 	async function handleDelete(id: string) {
-		if (!window.confirm(t("applications.confirmDelete"))) return;
+		if (!(await confirm(t("applications.confirmDelete")))) return;
 		try {
 			await deleteApplication(id);
 			showToast(t("applications.toasts.deleted"), "success");
@@ -324,6 +326,7 @@ export function ApplicationsPage() {
 					onClose={() => setEditing(null)}
 				/>
 			)}
+			{confirmDialog}
 		</AppShell>
 	);
 }


### PR DESCRIPTION
Adds a reusable `ConfirmDialog` + `useConfirm()` hook and replaces all five
    `window.confirm()` call sites (application delete ×2, note, interview,
    contact) with it — issue #17. The native dialog couldn't be styled and was
    inconsistent with the rest of the UI.
  - `ApplicationFormModal` no longer closes on an outside click, which was
    silently discarding unsaved form input.
  - Job description is now editable inline from the Overview tab (pencil icon →                                                                                                               
    auto-grow textarea → save), instead of requiring the full multi-field "Edit
    application" modal.
  - Notes and job description now render lightweight markup — `**bold**` and                                                                                                                  
    `-`/`1.` lists — via a small hand-rolled `FormattedText` component (no new
    dependency).
  - Notes default to newest-first (was oldest-first), with a toggle to flip                                                                                                                   
    back to oldest-first.
